### PR TITLE
Update gudou.m3u and sxg.m3u

### DIFF
--- a/main/gudou.m3u
+++ b/main/gudou.m3u
@@ -1,117 +1,257 @@
 #EXTM3U
-#EXTINF:-1 tvg-id="106" tvg-name="CCTV4K" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV4k.png" group-title="谷豆本地",CCTV4K
+#EXTINF:-1,tvg-id="CCTV4K" tvg-name="CCTV4K" tvg-logo="https://epg.112114.xyz/logo/CCTV4K.png" group-title="央视",CCTV4K
 http://192.168.10.1:5678/gudou.php?id=4005
-#EXTINF:-1 tvg-id="7249" tvg-name="CCTV16" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV16.png" group-title="谷豆本地",CCTV16-4K
+#EXTINF:-1,tvg-id="CCTV16" tvg-name="CCTV16" tvg-logo="https://epg.112114.xyz/logo/CCTV16.png" group-title="央视",CCTV16-4K
 http://192.168.10.1:5678/gudou.php?id=4010
-#EXTINF:-1 tvg-id="7251" tvg-name="广东综艺" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/GDTVENT.png" group-title="谷豆本地",广东综艺4K
+#EXTINF:-1,tvg-id="广东综艺" tvg-name="广东综艺" tvg-logo="https://epg.112114.xyz/logo/广东综艺.png" group-title="广东",广东综艺4K
 http://192.168.10.1:5678/gudou.php?id=GDZYHD4K_38000
-#EXTINF:-1 tvg-id="1" tvg-name="CCTV1" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV1.png" group-title="谷豆本地",CCTV1
-http://192.168.10.1:5678/gudou.php?id=CCTV1HD_7000
-#EXTINF:-1 tvg-id="2" tvg-name="CCTV2" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV2.png" group-title="谷豆本地",CCTV2
-http://192.168.10.1:5678/gudou.php?id=CCTV2HD_7000
-#EXTINF:-1 tvg-id="3" tvg-name="CCTV3" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV3.png" group-title="谷豆本地",CCTV3
-http://192.168.10.1:5678/gudou.php?id=CCTV3HD_7000
-#EXTINF:-1 tvg-id="4" tvg-name="CCTV4" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV4.png" group-title="谷豆本地",CCTV4
-http://192.168.10.1:5678/gudou.php?id=CCTV-4HD_7500
-#EXTINF:-1 tvg-id="5" tvg-name="CCTV5" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV5.png" group-title="谷豆本地",CCTV5
-http://192.168.10.1:5678/gudou.php?id=1605_4500
-#EXTINF:-1 tvg-id="6" tvg-name="CCTV5+" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV5+.png" group-title="谷豆本地",CCTV5+
-http://192.168.10.1:5678/gudou.php?id=1403_4500
-#EXTINF:-1 tvg-id="7" tvg-name="CCTV6" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV6.png" group-title="谷豆本地",CCTV6
-http://192.168.10.1:5678/gudou.php?id=CCTV6HD_7000
-#EXTINF:-1 tvg-id="8" tvg-name="CCTV7" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV7.png" group-title="谷豆本地",CCTV7
-http://192.168.10.1:5678/gudou.php?id=CCTV7HD_7000
-#EXTINF:-1 tvg-id="9" tvg-name="CCTV8" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV8.png" group-title="谷豆本地",CCTV8
-http://192.168.10.1:5678/gudou.php?id=CCTV8HD_7000
-#EXTINF:-1 tvg-id="10" tvg-name="CCTV9" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV9.png" group-title="谷豆本地",CCTV9
-http://192.168.10.1:5678/gudou.php?id=CCTV9HD_7000
-#EXTINF:-1 tvg-id="11" tvg-name="CCTV10" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV10.png" group-title="谷豆本地",CCTV10
-http://192.168.10.1:5678/gudou.php?id=CCTV10HD_7000
-#EXTINF:-1 tvg-id="12" tvg-name="CCTV11" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV11.png" group-title="谷豆本地",CCTV11
-http://192.168.10.1:5678/gudou.php?id=CCTV-11HD_7500
-#EXTINF:-1 tvg-id="13" tvg-name="CCTV12" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV12.png" group-title="谷豆本地",CCTV12
-http://192.168.10.1:5678/gudou.php?id=CCTV12HD_7000
-#EXTINF:-1 tvg-id="14" tvg-name="CCTV13" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV13.png" group-title="谷豆本地",CCTV13
-http://192.168.10.1:5678/gudou.php?id=1613
-#EXTINF:-1 tvg-id="15" tvg-name="CCTV14" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV14.png" group-title="谷豆本地",CCTV14
-http://192.168.10.1:5678/gudou.php?id=CCTV14HD_7000
-#EXTINF:-1 tvg-id="16" tvg-name="CCTV15" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV15.png" group-title="谷豆本地",CCTV15
-http://192.168.10.1:5678/gudou.php?id=CCTV-15HD_7500
-#EXTINF:-1 tvg-id="7249" tvg-name="CCTV16" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV16.png" group-title="谷豆本地",CCTV16
-http://192.168.10.1:5678/gudou.php?id=1617_4500
-#EXTINF:-1 tvg-id="17" tvg-name="CCTV17" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/CCTV17.png" group-title="谷豆本地",CCTV17
-http://192.168.10.1:5678/gudou.php?id=CCTV17HD
-#EXTINF:-1 tvg-id="20" tvg-name="CGTN" tvg-logo="http://epg.51zmt.top:8000/tb1/CCTV/cgtn.png" group-title="谷豆本地",CGTN-标清
-http://192.168.10.1:5678/gudou.php?id=CCTV15news_1500
-#EXTINF:-1 tvg-id="33" tvg-name="广东卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/guangdong.png" group-title="谷豆本地",广东卫视
-http://192.168.10.1:5678/gudou.php?id=guangdongHD_7000
-#EXTINF:-1 tvg-id="34" tvg-name="深圳卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/shenzhen.png" group-title="谷豆本地",深圳卫视
-http://192.168.10.1:5678/gudou.php?id=shenzhenHD_7000
-#EXTINF:-1 tvg-id="31" tvg-name="东方卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/dongfang.png" group-title="谷豆本地",东方卫视
-http://192.168.10.1:5678/gudou.php?id=dongfangHD_7000
-#EXTINF:-1 tvg-id="30" tvg-name="北京卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/beijing.png" group-title="谷豆本地",北京卫视
-http://192.168.10.1:5678/gudou.php?id=beijingHD_7000
-#EXTINF:-1 tvg-id="27" tvg-name="湖南卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/hunan.png" group-title="谷豆本地",湖南卫视
-http://192.168.10.1:5678/gudou.php?id=hunanHD_7000
-#EXTINF:-1 tvg-id="50" tvg-name="江西卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/jiangxi.png" group-title="谷豆本地",江西卫视
-http://192.168.10.1:5678/gudou.php?id=jiangxiHD_7000
-#EXTINF:-1 tvg-id="56" tvg-name="四川卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/sichuan.png" group-title="谷豆本地",四川卫视
-http://192.168.10.1:5678/gudou.php?id=sichuanHD_7000
-#EXTINF:-1 tvg-id="29" tvg-name="江苏卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/jiangsu.png" group-title="谷豆本地",江苏卫视
-http://192.168.10.1:5678/gudou.php?id=jiangsuHD_7000
-#EXTINF:-1 tvg-id="28" tvg-name="浙江卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/zhejiang.png" group-title="谷豆本地",浙江卫视
-http://192.168.10.1:5678/gudou.php?id=zhejiangHD_7000
-#EXTINF:-1 tvg-id="39" tvg-name="天津卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/tianjin.png" group-title="谷豆本地",天津卫视
-http://192.168.10.1:5678/gudou.php?id=1415_4500
-#EXTINF:-1 tvg-id="45" tvg-name="河北卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/hebei.png" group-title="谷豆本地",河北卫视
-http://192.168.10.1:5678/gudou.php?id=1426_4500
-#EXTINF:-1 tvg-id="40" tvg-name="重庆卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/chongqing.png" group-title="谷豆本地",重庆卫视
-http://192.168.10.1:5678/gudou.php?id=chongqingHD_7000
-#EXTINF:-1 tvg-id="44" tvg-name="贵州卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/guizhou.png" group-title="谷豆本地",贵州卫视
-http://192.168.10.1:5678/gudou.php?id=guizhouHD_7000
-#EXTINF:-1 tvg-id="36" tvg-name="辽宁卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/liaoning.png" group-title="谷豆本地",辽宁卫视
-http://192.168.10.1:5678/gudou.php?id=liaoningHD_7000
-#EXTINF:-1 tvg-id="48" tvg-name="湖北卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/hubei.png" group-title="谷豆本地",湖北卫视
-http://192.168.10.1:5678/gudou.php?id=hubeiHD_7000
-#EXTINF:-1 tvg-id="32" tvg-name="安徽卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/anhui.png" group-title="谷豆本地",安徽卫视
-http://192.168.10.1:5678/gudou.php?id=anhuiHD_7000
-#EXTINF:-1 tvg-id="46" tvg-name="黑龙江卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/heilongjiang.png" group-title="谷豆本地",黑龙江卫视
-http://192.168.10.1:5678/gudou.php?id=heilongjiangHD_7000
-#EXTINF:-1 tvg-id="37" tvg-name="旅游卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/lvyou.png" group-title="谷豆本地",海南卫视
-http://192.168.10.1:5678/gudou.php?id=1451_4500
-#EXTINF:-1 tvg-id="55" tvg-name="陕西卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/shanxi.png" group-title="谷豆本地",陕西卫视
-http://192.168.10.1:5678/gudou.php?id=1452_4500
-#EXTINF:-1 tvg-id="41" tvg-name="东南卫视" tvg-logo="http://epg.51zmt.top:8000/tb1/ws/dongnan.png" group-title="谷豆本地",东南卫视
-http://192.168.10.1:5678/gudou.php?id=dongnanweishiHD
-#EXTINF:-1 tvg-id="126" tvg-name="翡翠台" tvg-logo="http://epg.51zmt.top:8000/tb1/gt/TVB翡翠台.png" group-title="谷豆本地",翡翠台
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/G导视.png" group-title="其他",G导视高清
+http://192.168.10.1:5678/gudou.php?id=GHDdaoshi_7500
+#EXTINF:-1,tvg-id="翡翠台" tvg-name="翡翠台" tvg-logo="https://epg.112114.xyz/logo/翡翠台.png" group-title="港澳台",翡翠台
 http://192.168.10.1:5678/gudou.php?id=1350_4500
-#EXTINF:-1 tvg-id="127" tvg-name="明珠台" tvg-logo="http://epg.51zmt.top:8000/tb1/gt/TVB明珠台.png" group-title="谷豆本地",明珠台
+#EXTINF:-1,tvg-id="明珠台" tvg-name="明珠台" tvg-logo="https://epg.112114.xyz/logo/明珠台.png" group-title="港澳台",明珠台
 http://192.168.10.1:5678/gudou.php?id=1351_4500
-#EXTINF:-1 tvg-id="141" tvg-name="凤凰中文" tvg-logo="http://epg.51zmt.top:8000/tb1/gt/fenghuangzhongwen.png" group-title="谷豆本地",凤凰中文-标清
+#EXTINF:-1,tvg-id="凤凰中文" tvg-name="凤凰中文" tvg-logo="https://epg.112114.xyz/logo/凤凰中文.png" group-title="香港",凤凰中文
 http://192.168.10.1:5678/gudou.php?id=fhzw_1500
-#EXTINF:-1 tvg-id="" tvg-name="星空卫视" tvg-logo="https://pix1.tvzhe.com/images/logo/channel/XINGKONG1/XINGKONG1.jpg" group-title="谷豆本地",星空卫视-标清
+#EXTINF:-1,tvg-id="星空卫视" tvg-name="星空卫视" tvg-logo="https://epg.112114.xyz/logo/星空卫视.png" group-title="卫视",星空卫视
 http://192.168.10.1:5678/gudou.php?id=xingkong_1500
-#EXTINF:-1 tvg-id="" tvg-name="澳亚卫视" tvg-logo="http://9102920.s21i.faiusr.com/4/ABUIABAEGAAgz8-cuAUoyO-DiAcw7Q047A0!300x300.png" group-title="谷豆本地",澳亚卫视-标清
+#EXTINF:-1,tvg-id="澳亚卫视" tvg-name="澳亚卫视" tvg-logo="https://epg.112114.xyz/logo/澳亚卫视.png" group-title="卫视",澳亚卫视
 http://192.168.10.1:5678/gudou.php?id=aoya_1500
-#EXTINF:-1 tvg-id="6241" tvg-name="CHC高清电影" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/CHC3.jpg" group-title="谷豆本地",CHC高清电影
+#EXTINF:-1,tvg-id="CCTV1" tvg-name="CCTV1" tvg-logo="https://epg.112114.xyz/logo/CCTV1.png" group-title="央视",CCTV1
+http://192.168.10.1:5678/gudou.php?id=CCTV1HD_7000
+#EXTINF:-1,tvg-id="CCTV2" tvg-name="CCTV2" tvg-logo="https://epg.112114.xyz/logo/CCTV2.png" group-title="央视",CCTV2
+http://192.168.10.1:5678/gudou.php?id=CCTV2HD_7000
+#EXTINF:-1,tvg-id="CCTV3" tvg-name="CCTV3" tvg-logo="https://epg.112114.xyz/logo/CCTV3.png" group-title="央视",CCTV3
+http://192.168.10.1:5678/gudou.php?id=CCTV3HD_7000
+#EXTINF:-1,tvg-id="CCTV4" tvg-name="CCTV4" tvg-logo="https://epg.112114.xyz/logo/CCTV4.png" group-title="央视",CCTV4
+http://192.168.10.1:5678/gudou.php?id=CCTV-4HD_7500
+#EXTINF:-1,tvg-id="CCTV5" tvg-name="CCTV5" tvg-logo="https://epg.112114.xyz/logo/CCTV5.png" group-title="央视",CCTV5
+http://192.168.10.1:5678/gudou.php?id=CCTV5HD_7000
+#EXTINF:-1,tvg-id="CCTV5+" tvg-name="CCTV5+" tvg-logo="https://epg.112114.xyz/logo/CCTV5+.png" group-title="央视",CCTV5+
+http://192.168.10.1:5678/gudou.php?id=CCTV5plusHD_7000
+#EXTINF:-1,tvg-id="CCTV6" tvg-name="CCTV6" tvg-logo="https://epg.112114.xyz/logo/CCTV6.png" group-title="央视",CCTV6
+http://192.168.10.1:5678/gudou.php?id=CCTV6HD_7000
+#EXTINF:-1,tvg-id="CCTV7" tvg-name="CCTV7" tvg-logo="https://epg.112114.xyz/logo/CCTV7.png" group-title="央视",CCTV7
+http://192.168.10.1:5678/gudou.php?id=CCTV7HD_7000
+#EXTINF:-1,tvg-id="CCTV8" tvg-name="CCTV8" tvg-logo="https://epg.112114.xyz/logo/CCTV8.png" group-title="央视",CCTV8
+http://192.168.10.1:5678/gudou.php?id=CCTV8HD_7000
+#EXTINF:-1,tvg-id="CCTV9" tvg-name="CCTV9" tvg-logo="https://epg.112114.xyz/logo/CCTV9.png" group-title="央视",CCTV9
+http://192.168.10.1:5678/gudou.php?id=CCTV9HD_7000
+#EXTINF:-1,tvg-id="CCTV10" tvg-name="CCTV10" tvg-logo="https://epg.112114.xyz/logo/CCTV10.png" group-title="央视",CCTV10
+http://192.168.10.1:5678/gudou.php?id=CCTV10HD_7000
+#EXTINF:-1,tvg-id="CCTV11" tvg-name="CCTV11" tvg-logo="https://epg.112114.xyz/logo/CCTV11.png" group-title="央视",CCTV11
+http://192.168.10.1:5678/gudou.php?id=CCTV-11HD_7500
+#EXTINF:-1,tvg-id="CCTV12" tvg-name="CCTV12" tvg-logo="https://epg.112114.xyz/logo/CCTV12.png" group-title="央视",CCTV12
+http://192.168.10.1:5678/gudou.php?id=CCTV12HD_7000
+#EXTINF:-1,tvg-id="CCTV13" tvg-name="CCTV13" tvg-logo="https://epg.112114.xyz/logo/CCTV13.png" group-title="央视",CCTV13
+http://192.168.10.1:5678/gudou.php?id=1613
+#EXTINF:-1,tvg-id="CCTV14" tvg-name="CCTV14" tvg-logo="https://epg.112114.xyz/logo/CCTV14.png" group-title="央视",CCTV14
+http://192.168.10.1:5678/gudou.php?id=CCTV14HD_7000
+#EXTINF:-1,tvg-id="CCTV15" tvg-name="CCTV15" tvg-logo="https://epg.112114.xyz/logo/CCTV15.png" group-title="央视",CCTV15
+http://192.168.10.1:5678/gudou.php?id=CCTV-15HD_7500
+#EXTINF:-1,tvg-id="CCTV16" tvg-name="CCTV16" tvg-logo="https://epg.112114.xyz/logo/CCTV16.png" group-title="央视",CCTV16
+http://192.168.10.1:5678/gudou.php?id=1617_4500
+#EXTINF:-1,tvg-id="CCTV17" tvg-name="CCTV17" tvg-logo="https://epg.112114.xyz/logo/CCTV17.png" group-title="央视",CCTV17
+http://192.168.10.1:5678/gudou.php?id=CCTV17HD
+#EXTINF:-1,tvg-id="CGTN" tvg-name="CGTN" tvg-logo="https://epg.112114.xyz/logo/CGTN.png" group-title="央视",CGTN
+http://192.168.10.1:5678/gudou.php?id=CCTV15news_1500
+#EXTINF:-1,tvg-id="广东卫视" tvg-name="广东卫视" tvg-logo="https://epg.112114.xyz/logo/广东卫视.png" group-title="卫视",广东卫视
+http://192.168.10.1:5678/gudou.php?id=guangdongHD_7000
+#EXTINF:-1,tvg-id="深圳卫视" tvg-name="深圳卫视" tvg-logo="https://epg.112114.xyz/logo/深圳卫视.png" group-title="卫视",深圳卫视
+http://192.168.10.1:5678/gudou.php?id=shenzhenHD_7000
+#EXTINF:-1,tvg-id="东方卫视" tvg-name="东方卫视" tvg-logo="https://epg.112114.xyz/logo/东方卫视.png" group-title="卫视",东方卫视
+http://192.168.10.1:5678/gudou.php?id=dongfangHD_7000
+#EXTINF:-1,tvg-id="北京卫视" tvg-name="北京卫视" tvg-logo="https://epg.112114.xyz/logo/北京卫视.png" group-title="卫视",北京卫视
+http://192.168.10.1:5678/gudou.php?id=beijingHD_7000
+#EXTINF:-1,tvg-id="湖南卫视" tvg-name="湖南卫视" tvg-logo="https://epg.112114.xyz/logo/湖南卫视.png" group-title="卫视",湖南卫视
+http://192.168.10.1:5678/gudou.php?id=hunanHD_7000
+#EXTINF:-1,tvg-id="江西卫视" tvg-name="江西卫视" tvg-logo="https://epg.112114.xyz/logo/江西卫视.png" group-title="卫视",江西卫视
+http://192.168.10.1:5678/gudou.php?id=jiangxiHD_7000
+#EXTINF:-1,tvg-id="四川卫视" tvg-name="四川卫视" tvg-logo="https://epg.112114.xyz/logo/四川卫视.png" group-title="卫视",四川卫视
+http://192.168.10.1:5678/gudou.php?id=sichuanHD_7000
+#EXTINF:-1,tvg-id="江苏卫视" tvg-name="江苏卫视" tvg-logo="https://epg.112114.xyz/logo/江苏卫视.png" group-title="卫视",江苏卫视
+http://192.168.10.1:5678/gudou.php?id=jiangsuHD_7000
+#EXTINF:-1,tvg-id="浙江卫视" tvg-name="浙江卫视" tvg-logo="https://epg.112114.xyz/logo/浙江卫视.png" group-title="卫视",浙江卫视
+http://192.168.10.1:5678/gudou.php?id=zhejiangHD_7000
+#EXTINF:-1,tvg-id="天津卫视" tvg-name="天津卫视" tvg-logo="https://epg.112114.xyz/logo/天津卫视.png" group-title="卫视",天津卫视
+http://192.168.10.1:5678/gudou.php?id=1415_4500
+#EXTINF:-1,tvg-id="河北卫视" tvg-name="河北卫视" tvg-logo="https://epg.112114.xyz/logo/河北卫视.png" group-title="卫视",河北卫视
+http://192.168.10.1:5678/gudou.php?id=1426_4500
+#EXTINF:-1,tvg-id="重庆卫视" tvg-name="重庆卫视" tvg-logo="https://epg.112114.xyz/logo/重庆卫视.png" group-title="卫视",重庆卫视
+http://192.168.10.1:5678/gudou.php?id=chongqingHD_7000
+#EXTINF:-1,tvg-id="贵州卫视" tvg-name="贵州卫视" tvg-logo="https://epg.112114.xyz/logo/贵州卫视.png" group-title="卫视",贵州卫视
+http://192.168.10.1:5678/gudou.php?id=guizhouHD_7000
+#EXTINF:-1,tvg-id="辽宁卫视" tvg-name="辽宁卫视" tvg-logo="https://epg.112114.xyz/logo/辽宁卫视.png" group-title="卫视",辽宁卫视
+http://192.168.10.1:5678/gudou.php?id=liaoningHD_7000
+#EXTINF:-1,tvg-id="湖北卫视" tvg-name="湖北卫视" tvg-logo="https://epg.112114.xyz/logo/湖北卫视.png" group-title="卫视",湖北卫视
+http://192.168.10.1:5678/gudou.php?id=hubeiHD_7000
+#EXTINF:-1,tvg-id="安徽卫视" tvg-name="安徽卫视" tvg-logo="https://epg.112114.xyz/logo/安徽卫视.png" group-title="卫视",安徽卫视
+http://192.168.10.1:5678/gudou.php?id=anhuiHD_7000
+#EXTINF:-1,tvg-id="黑龙江卫视" tvg-name="黑龙江卫视" tvg-logo="https://epg.112114.xyz/logo/黑龙江卫视.png" group-title="卫视",黑龙江卫视
+http://192.168.10.1:5678/gudou.php?id=heilongjiangHD_7000
+#EXTINF:-1,tvg-id="海南卫视" tvg-name="海南卫视" tvg-logo="https://epg.112114.xyz/logo/海南卫视.png" group-title="卫视",海南卫视
+http://192.168.10.1:5678/gudou.php?id=1451_4500
+#EXTINF:-1,tvg-id="陕西卫视" tvg-name="陕西卫视" tvg-logo="https://epg.112114.xyz/logo/陕西卫视.png" group-title="卫视",陕西卫视
+http://192.168.10.1:5678/gudou.php?id=1452_4500
+#EXTINF:-1,tvg-id="东南卫视" tvg-name="东南卫视" tvg-logo="https://epg.112114.xyz/logo/东南卫视.png" group-title="卫视",东南卫视
+http://192.168.10.1:5678/gudou.php?id=dongnanweishiHD
+#EXTINF:-1,tvg-id="CHC高清电影" tvg-name="CHC高清电影" tvg-logo="https://epg.112114.xyz/logo/CHC高清电影.png" group-title="其他",CHC高清电影
 http://192.168.10.1:5678/gudou.php?id=CHCHD_7000
-#EXTINF:-1 tvg-id="6244" tvg-name="求索记录" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/QSJL.png" group-title="谷豆本地",求索纪录
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐游.png" group-title="其他",乐游
+http://192.168.10.1:5678/gudou.php?id=quanjishiHD_7000
+#EXTINF:-1,tvg-id="求索纪录" tvg-name="求索纪录" tvg-logo="https://epg.112114.xyz/logo/求索纪录.png" group-title="其他",求索纪录
 http://192.168.10.1:5678/gudou.php?id=QSJLHD_7000
-#EXTINF:-1 tvg-id="6240" tvg-name="求索科学" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/QSKX.png" group-title="谷豆本地",求索科学
+#EXTINF:-1,tvg-id="求索科学" tvg-name="求索科学" tvg-logo="https://epg.112114.xyz/logo/求索科学.png" group-title="其他",求索科学
 http://192.168.10.1:5678/gudou.php?id=qiusuokexueHD_7000
-#EXTINF:-1 tvg-id="6242" tvg-name="求索动物" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/QSDW.png" group-title="谷豆本地",求索动物
+#EXTINF:-1,tvg-id="求索动物" tvg-name="求索动物" tvg-logo="https://epg.112114.xyz/logo/求索动物.png" group-title="其他",求索动物
 http://192.168.10.1:5678/gudou.php?id=QSDWHD_7000
-#EXTINF:-1 tvg-id="7242" tvg-name="魅力足球" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/meilizuqiu.png" group-title="谷豆本地",魅力足球
+#EXTINF:-1,tvg-id="浙江求索生活" tvg-name="浙江求索生活" tvg-logo="https://epg.112114.xyz/logo/浙江求索生活.png" group-title="其他",求索生活
+http://192.168.10.1:5678/gudou.php?id=QSSHHD_7000
+#EXTINF:-1,tvg-id="魅力足球" tvg-name="魅力足球" tvg-logo="https://epg.112114.xyz/logo/魅力足球.png" group-title="其他",魅力足球
 http://192.168.10.1:5678/gudou.php?id=meiliyinyueHD_7000
-#EXTINF:-1 tvg-id="1964" tvg-name="劲爆体育" tvg-logo="http://epg.51zmt.top:8000/tb1/qt/jinbaotiyu.jpg" group-title="谷豆本地",劲爆体育
+#EXTINF:-1,tvg-id="SITV劲爆体育" tvg-name="SITV劲爆体育" tvg-logo="https://epg.112114.xyz/logo/SITV劲爆体育.png" group-title="其他",劲爆体育
 http://192.168.10.1:5678/gudou.php?id=jinbaotiyuHD_7000
-#EXTINF:-1 tvg-id="7125" tvg-name="珠江频道" tvg-logo="http://epg.51zmt.top:8000/tb1/gt/zhujiang.png" group-title="谷豆本地",广东珠江
+#EXTINF:-1,tvg-id="广东珠江" tvg-name="广东珠江" tvg-logo="https://epg.112114.xyz/logo/广东珠江.png" group-title="广东",广东珠江
 http://192.168.10.1:5678/gudou.php?id=gdzhujiangHD_7500
-#EXTINF:-1 tvg-id="6013" tvg-name="广东体育" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/GDTV3.png" group-title="谷豆本地",广东体育
+#EXTINF:-1,tvg-id="广东体育" tvg-name="广东体育" tvg-logo="https://epg.112114.xyz/logo/广东体育.png" group-title="广东",广东体育
 http://192.168.10.1:5678/gudou.php?id=gdsportsHD_7000
-#EXTINF:-1 tvg-id="7252" tvg-name="广东经济" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/GDTVECO.png" group-title="谷豆本地",广东经济科教
+#EXTINF:-1,tvg-id="广东经济科教" tvg-name="广东经济科教" tvg-logo="https://epg.112114.xyz/logo/广东经济科教.png" group-title="广东",广东经济科教
 http://192.168.10.1:5678/gudou.php?id=GDjingjikejiaoHD_7000
-#EXTINF:-1 tvg-id="6016" tvg-name="广东新闻" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/GDTV6.png" group-title="谷豆本地",广东新闻-标清
+#EXTINF:-1,tvg-id="广东新闻" tvg-name="广东新闻" tvg-logo="https://epg.112114.xyz/logo/广东新闻.png" group-title="广东",广东新闻
 http://192.168.10.1:5678/gudou.php?id=gdnews_1500
-#EXTINF:-1 tvg-id="6014" tvg-name="广东公共" tvg-logo="http://epg.51zmt.top:8000/tb1/sheng/GDTV4.png" group-title="谷豆本地",广东公共-标清
+#EXTINF:-1,tvg-id="广东公共" tvg-name="广东公共" tvg-logo="https://epg.112114.xyz/logo/广东公共.png" group-title="广东",广东公共
 http://192.168.10.1:5678/gudou.php?id=gdpublic_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/大湾区卫视.png" group-title="卫视",大湾区卫视
+http://192.168.10.1:5678/gudou.php?id=gdnanfang_1500
+#EXTINF:-1,tvg-id="广东影视" tvg-name="广东影视" tvg-logo="https://epg.112114.xyz/logo/广东影视.png" group-title="广东",广东影视
+http://192.168.10.1:5678/gudou.php?id=gdyingshi_1500
+#EXTINF:-1,tvg-id="嘉佳卡通" tvg-name="嘉佳卡通" tvg-logo="https://epg.112114.xyz/logo/嘉佳卡通.png" group-title="其他",嘉佳卡通
+http://192.168.10.1:5678/gudou.php?id=gdjiajiacartoon_1500
+#EXTINF:-1,tvg-id="广东少儿" tvg-name="广东少儿" tvg-logo="https://epg.112114.xyz/logo/广东少儿.png" group-title="广东",广东少儿
+http://192.168.10.1:5678/gudou.php?id=gdshaoer_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/汕头综合.png" group-title="其他",汕头综合
+http://192.168.10.1:5678/gudou.php?id=shantouyitaogaoqing_4500
+#EXTINF:-1,tvg-id="汕头经济生活" tvg-name="汕头经济生活" tvg-logo="https://epg.112114.xyz/logo/汕头经济生活.png" group-title="其他",汕头经济生活
+http://192.168.10.1:5678/gudou.php?id=shantouertaogaoqing_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/汕头文旅体育.png" group-title="其他",汕头文旅体育
+http://192.168.10.1:5678/gudou.php?id=2508_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/潮州综合.png" group-title="其他",潮州综合
+http://192.168.10.1:5678/gudou.php?id=3131
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/潮州民生.png" group-title="其他",潮州民生
+http://192.168.10.1:5678/gudou.php?id=3132
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/中山综合.png" group-title="其他",中山综合
+http://192.168.10.1:5678/gudou.php?id=3665
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/中山公共.png" group-title="其他",中山公共
+http://192.168.10.1:5678/gudou.php?id=3663
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/中山教育.png" group-title="其他",中山教育
+http://192.168.10.1:5678/gudou.php?id=3664
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/鹤山综合.png" group-title="其他",鹤山综合
+http://192.168.10.1:5678/gudou.php?id=3709
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/梅州1.png" group-title="其他",梅州1
+http://192.168.10.1:5678/gudou.php?id=meizhou1HD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/梅州2.png" group-title="其他",梅州2
+http://192.168.10.1:5678/gudou.php?id=meizhou2HD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/增城电视台.png" group-title="其他",增城电视台
+http://192.168.10.1:5678/gudou.php?id=2079
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/东莞新闻综合.png" group-title="其他",东莞新闻综合
+http://192.168.10.1:5678/gudou.php?id=2121
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/东莞生活资讯.png" group-title="其他",东莞生活资讯
+http://192.168.10.1:5678/gudou.php?id=2122
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/佛山综合.png" group-title="其他",佛山综合
+http://192.168.10.1:5678/gudou.php?id=foshanzongheHD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/佛山公共.png" group-title="其他",佛山公共
+http://192.168.10.1:5678/gudou.php?id=foshangonggongHD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/佛山影视.png" group-title="其他",佛山影视
+http://192.168.10.1:5678/gudou.php?id=foshanyingshiHD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南海综合.png" group-title="其他",南海综合
+http://192.168.10.1:5678/gudou.php?id=nanhaiHD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/顺德综合.png" group-title="其他",顺德综合
+http://192.168.10.1:5678/gudou.php?id=shundeHD_4500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/斗门融媒.png" group-title="其他",斗门融媒
+http://192.168.10.1:5678/gudou.php?id=2207
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/惠州1.png" group-title="其他",惠州1
+http://192.168.10.1:5678/gudou.php?id=2314
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/惠州2.png" group-title="其他",惠州2
+http://192.168.10.1:5678/gudou.php?id=2316
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/博罗综合.png" group-title="其他",博罗综合
+http://192.168.10.1:5678/gudou.php?id=2305
+#EXTINF:-1,tvg-id="广州综合" tvg-name="广州综合" tvg-logo="https://epg.112114.xyz/logo/广州综合.png" group-title="其他",广州综合
+http://192.168.10.1:5678/gudou.php?id=guangzhou_1500
+#EXTINF:-1,tvg-id="广州新闻" tvg-name="广州新闻" tvg-logo="https://epg.112114.xyz/logo/广州新闻.png" group-title="其他",广州新闻
+http://192.168.10.1:5678/gudou.php?id=gznews_1500
+#EXTINF:-1,tvg-id="广州法治" tvg-name="广州法治" tvg-logo="https://epg.112114.xyz/logo/广州法治.png" group-title="其他",广州法治
+http://192.168.10.1:5678/gudou.php?id=gzeconomic_1500
+#EXTINF:-1,tvg-id="广州竞赛" tvg-name="广州竞赛" tvg-logo="https://epg.112114.xyz/logo/广州竞赛.png" group-title="其他",广州竞赛
+http://192.168.10.1:5678/gudou.php?id=gzcompetition_1500
+#EXTINF:-1,tvg-id="广州影视" tvg-name="广州影视" tvg-logo="https://epg.112114.xyz/logo/广州影视.png" group-title="其他",广州影视
+http://192.168.10.1:5678/gudou.php?id=gzfilms_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/湛江综合.png" group-title="其他",湛江综合
+http://192.168.10.1:5678/gudou.php?id=zhanjiangzonghe_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/湛江公共.png" group-title="其他",湛江公共
+http://192.168.10.1:5678/gudou.php?id=zhanjianggonggong_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/韶关新闻综合.png" group-title="其他",韶关新闻综合
+http://192.168.10.1:5678/gudou.php?id=shaoguanzonghe_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/韶关绿色生活.png" group-title="其他",韶关绿色生活
+http://192.168.10.1:5678/gudou.php?id=shaoguangonggong_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/始兴综合.png" group-title="其他",始兴综合
+http://192.168.10.1:5678/gudou.php?id=2641
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/江门综合.png" group-title="其他",江门综合
+http://192.168.10.1:5678/gudou.php?id=3712_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/江门侨乡生活.png" group-title="其他",江门侨乡生活
+http://192.168.10.1:5678/gudou.php?id=jiangmenyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/新会综合.png" group-title="其他",新会综合
+http://192.168.10.1:5678/gudou.php?id=xinhui_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/佛冈.png" group-title="其他",佛冈
+http://192.168.10.1:5678/gudou.php?id=2405
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/怀集综合.png" group-title="其他",怀集综合
+http://192.168.10.1:5678/gudou.php?id=2805
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/云浮综合.png" group-title="其他",云浮综合
+http://192.168.10.1:5678/gudou.php?id=yunfuyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/云浮文旅.png" group-title="其他",云浮文旅
+http://192.168.10.1:5678/gudou.php?id=yunfuertao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/珠海1.png" group-title="其他",珠海1
+http://192.168.10.1:5678/gudou.php?id=zhuhaiyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/珠海2.png" group-title="其他",珠海2
+http://192.168.10.1:5678/gudou.php?id=zhuhaiertao_1500
+#EXTINF:-1,tvg-id="河源综合" tvg-name="河源综合" tvg-logo="https://epg.112114.xyz/logo/河源综合.png" group-title="其他",河源综合
+http://192.168.10.1:5678/gudou.php?id=heyuanyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/河源公共.png" group-title="其他",河源公共
+http://192.168.10.1:5678/gudou.php?id=heyuanertao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/肇庆综合.png" group-title="其他",肇庆综合
+http://192.168.10.1:5678/gudou.php?id=zhaoqingyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/肇庆生活服务.png" group-title="其他",肇庆生活服务
+http://192.168.10.1:5678/gudou.php?id=zhaoqingertao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/揭阳综合.png" group-title="其他",揭阳综合
+http://192.168.10.1:5678/gudou.php?id=jieyangyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/揭阳生活.png" group-title="其他",揭阳生活
+http://192.168.10.1:5678/gudou.php?id=jieyangertao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/清远新闻综合.png" group-title="其他",清远新闻综合
+http://192.168.10.1:5678/gudou.php?id=qingyuanzonghe_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/清远文旅生活.png" group-title="其他",清远文旅生活
+http://192.168.10.1:5678/gudou.php?id=qingyuangongong_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/汕尾新闻综合.png" group-title="其他",汕尾新闻综合
+http://192.168.10.1:5678/gudou.php?id=shanweiyitao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/汕尾文化生活.png" group-title="其他",汕尾文化生活
+http://192.168.10.1:5678/gudou.php?id=shanweiertao_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂一年级.png" group-title="其他",广州共享课堂一年级
+http://192.168.10.1:5678/gudou.php?id=2061_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂二年级.png" group-title="其他",广州共享课堂二年级
+http://192.168.10.1:5678/gudou.php?id=2062_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂三年级.png" group-title="其他",广州共享课堂三年级
+http://192.168.10.1:5678/gudou.php?id=2063_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂四年级.png" group-title="其他",广州共享课堂四年级
+http://192.168.10.1:5678/gudou.php?id=2064_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂五年级.png" group-title="其他",广州共享课堂五年级
+http://192.168.10.1:5678/gudou.php?id=2065_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂六年级.png" group-title="其他",广州共享课堂六年级
+http://192.168.10.1:5678/gudou.php?id=2066_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂初一.png" group-title="其他",广州共享课堂初一
+http://192.168.10.1:5678/gudou.php?id=2067_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂初二.png" group-title="其他",广州共享课堂初二
+http://192.168.10.1:5678/gudou.php?id=2068_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂初三.png" group-title="其他",广州共享课堂初三
+http://192.168.10.1:5678/gudou.php?id=2069_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂高一.png" group-title="其他",广州共享课堂高一
+http://192.168.10.1:5678/gudou.php?id=2070_1500
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广州共享课堂高二.png" group-title="其他",广州共享课堂高二
+http://192.168.10.1:5678/gudou.php?id=2071_1500

--- a/main/sxg.m3u
+++ b/main/sxg.m3u
@@ -1,489 +1,555 @@
 #EXTM3U
-#EXTINF:-1,tvg-id="CCTV1" tvg-name="CCTV1" tvg-logo="https://epg.112114.xyz/logo/CCTV1.png" group-title="央视",CCTV-1 综合 高清
+#EXTINF:-1,tvg-id="CCTV1" tvg-name="CCTV1" tvg-logo="https://epg.112114.xyz/logo/CCTV1.png" group-title="央视",CCTV-1 综合
 http://192.168.10.1:5678/sxg.php?id=CCTV-1H265_4000
-#EXTINF:-1,tvg-id="CCTV2" tvg-name="CCTV2" tvg-logo="https://epg.112114.xyz/logo/CCTV2.png" group-title="央视",CCTV-2 财经 高清
+#EXTINF:-1,tvg-id="CCTV2" tvg-name="CCTV2" tvg-logo="https://epg.112114.xyz/logo/CCTV2.png" group-title="央视",CCTV-2 财经
 http://192.168.10.1:5678/sxg.php?id=CCTV-2H265_4000
-#EXTINF:-1,tvg-id="CCTV3" tvg-name="CCTV3" tvg-logo="https://epg.112114.xyz/logo/CCTV3.png" group-title="央视",CCTV-3 综艺 高清
+#EXTINF:-1,tvg-id="CCTV3" tvg-name="CCTV3" tvg-logo="https://epg.112114.xyz/logo/CCTV3.png" group-title="央视",CCTV-3 综艺
 http://192.168.10.1:5678/sxg.php?id=CCTV-3H265_4000
-#EXTINF:-1,tvg-id="CCTV4" tvg-name="CCTV4" tvg-logo="https://epg.112114.xyz/logo/CCTV4.png" group-title="央视",CCTV-4 中文国际 高清
+#EXTINF:-1,tvg-id="CCTV4" tvg-name="CCTV4" tvg-logo="https://epg.112114.xyz/logo/CCTV4.png" group-title="央视",CCTV-4 中文国际
 http://192.168.10.1:5678/sxg.php?id=CCTV-4H265_4000
-#EXTINF:-1,tvg-id="CCTV5" tvg-name="CCTV5" tvg-logo="https://epg.112114.xyz/logo/CCTV5.png" group-title="央视",CCTV-5 体育 高清
+#EXTINF:-1,tvg-id="CCTV5" tvg-name="CCTV5" tvg-logo="https://epg.112114.xyz/logo/CCTV5.png" group-title="央视",CCTV-5 体育
 http://192.168.10.1:5678/sxg.php?id=CCTV-5H265_4000
-#EXTINF:-1,tvg-id="CCTV5" tvg-name="CCTV5" tvg-logo="https://epg.112114.xyz/logo/CCTV5.png" group-title="央视",CCTV-5⁺ 体育赛事 高清
+#EXTINF:-1,tvg-id="CCTV5+" tvg-name="CCTV5+" tvg-logo="https://epg.112114.xyz/logo/CCTV5+.png" group-title="央视",CCTV-5+ 体育赛事
 http://192.168.10.1:5678/sxg.php?id=CCTV-5plusH265_4000
-#EXTINF:-1,tvg-id="CCTV6" tvg-name="CCTV6" tvg-logo="https://epg.112114.xyz/logo/CCTV6.png" group-title="央视",CCTV-6 电影 高清
+#EXTINF:-1,tvg-id="CCTV6" tvg-name="CCTV6" tvg-logo="https://epg.112114.xyz/logo/CCTV6.png" group-title="央视",CCTV-6 电影
 http://192.168.10.1:5678/sxg.php?id=CCTV-6H265_4000
-#EXTINF:-1,tvg-id="CCTV7" tvg-name="CCTV7" tvg-logo="https://epg.112114.xyz/logo/CCTV7.png" group-title="央视",CCTV-7 国防军事 高清
+#EXTINF:-1,tvg-id="CCTV7" tvg-name="CCTV7" tvg-logo="https://epg.112114.xyz/logo/CCTV7.png" group-title="央视",CCTV-7 国防军事
 http://192.168.10.1:5678/sxg.php?id=CCTV-7H265_4000
-#EXTINF:-1,tvg-id="CCTV8" tvg-name="CCTV8" tvg-logo="https://epg.112114.xyz/logo/CCTV8.png" group-title="央视",CCTV-8 电视剧 高清
+#EXTINF:-1,tvg-id="CCTV8" tvg-name="CCTV8" tvg-logo="https://epg.112114.xyz/logo/CCTV8.png" group-title="央视",CCTV-8 电视剧
 http://192.168.10.1:5678/sxg.php?id=CCTV-8H265_4000
-#EXTINF:-1,tvg-id="CCTV9" tvg-name="CCTV9" tvg-logo="https://epg.112114.xyz/logo/CCTV9.png" group-title="央视",CCTV-9 纪录 高清
+#EXTINF:-1,tvg-id="CCTV9" tvg-name="CCTV9" tvg-logo="https://epg.112114.xyz/logo/CCTV9.png" group-title="央视",CCTV-9 纪录
 http://192.168.10.1:5678/sxg.php?id=CCTV-9H265_4000
-#EXTINF:-1,tvg-id="CCTV10" tvg-name="CCTV10" tvg-logo="https://epg.112114.xyz/logo/CCTV10.png" group-title="央视",CCTV-10 科教 高清
+#EXTINF:-1,tvg-id="CCTV10" tvg-name="CCTV10" tvg-logo="https://epg.112114.xyz/logo/CCTV10.png" group-title="央视",CCTV-10 科教
 http://192.168.10.1:5678/sxg.php?id=CCTV-10H265_4000
-#EXTINF:-1,tvg-id="CCTV11" tvg-name="CCTV11" tvg-logo="https://epg.112114.xyz/logo/CCTV11.png" group-title="央视",CCTV-11 戏曲 高清
+#EXTINF:-1,tvg-id="CCTV11" tvg-name="CCTV11" tvg-logo="https://epg.112114.xyz/logo/CCTV11.png" group-title="央视",CCTV-11 戏曲
 http://192.168.10.1:5678/sxg.php?id=CCTV-11-H265_4000
-#EXTINF:-1,tvg-id="CCTV12" tvg-name="CCTV12" tvg-logo="https://epg.112114.xyz/logo/CCTV12.png" group-title="央视",CCTV-12 社会与法 高清
+#EXTINF:-1,tvg-id="CCTV12" tvg-name="CCTV12" tvg-logo="https://epg.112114.xyz/logo/CCTV12.png" group-title="央视",CCTV-12 社会与法
 http://192.168.10.1:5678/sxg.php?id=CCTV-12H265_4000
-#EXTINF:-1,tvg-id="CCTV13" tvg-name="CCTV13" tvg-logo="https://epg.112114.xyz/logo/CCTV13.png" group-title="央视",CCTV-13 新闻 高清
+#EXTINF:-1,tvg-id="CCTV13" tvg-name="CCTV13" tvg-logo="https://epg.112114.xyz/logo/CCTV13.png" group-title="央视",CCTV-13 新闻
 http://192.168.10.1:5678/sxg.php?id=CCTV-xw_4000
-#EXTINF:-1,tvg-id="CCTV14" tvg-name="CCTV14" tvg-logo="https://epg.112114.xyz/logo/CCTV14.png" group-title="央视",CCTV-14 少儿 高清
+#EXTINF:-1,tvg-id="CCTV14" tvg-name="CCTV14" tvg-logo="https://epg.112114.xyz/logo/CCTV14.png" group-title="央视",CCTV-14 少儿
 http://192.168.10.1:5678/sxg.php?id=CCTV-14H265_4000
-#EXTINF:-1,tvg-id="CCTV15" tvg-name="CCTV15" tvg-logo="https://epg.112114.xyz/logo/CCTV15.png" group-title="央视",CCTV-15 音乐 高清
+#EXTINF:-1,tvg-id="CCTV15" tvg-name="CCTV15" tvg-logo="https://epg.112114.xyz/logo/CCTV15.png" group-title="央视",CCTV-15 音乐
 http://192.168.10.1:5678/sxg.php?id=CCTV-15-yyH265_4000
-#EXTINF:-1,tvg-id="CCTV16" tvg-name="CCTV16" tvg-logo="https://epg.112114.xyz/logo/CCTV16.png" group-title="央视",CCTV-16 奥林匹克 高清
+#EXTINF:-1,tvg-id="CCTV16" tvg-name="CCTV16" tvg-logo="https://epg.112114.xyz/logo/CCTV16.png" group-title="央视",CCTV-16 奥林匹克
 http://192.168.10.1:5678/sxg.php?id=CCTV-16_4000
 #EXTINF:-1,tvg-id="CCTV16" tvg-name="CCTV16" tvg-logo="https://epg.112114.xyz/logo/CCTV16.png" group-title="央视",CCTV-16 奥林匹克 4K
 http://192.168.10.1:5678/sxg.php?id=CCTV-16-4K_8000
-#EXTINF:-1,tvg-id="CCTV17" tvg-name="CCTV17" tvg-logo="https://epg.112114.xyz/logo/CCTV17.png" group-title="央视",CCTV-17 农业农村 高清
+#EXTINF:-1,tvg-id="CCTV17" tvg-name="CCTV17" tvg-logo="https://epg.112114.xyz/logo/CCTV17.png" group-title="央视",CCTV-17 农业农村
 http://192.168.10.1:5678/sxg.php?id=CCTV-17_4000
 #EXTINF:-1,tvg-id="CCTV4K" tvg-name="CCTV4K" tvg-logo="https://epg.112114.xyz/logo/CCTV4K.png" group-title="央视",CCTV-4K 超高清
 http://192.168.10.1:5678/sxg.php?id=ys4Kcq_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CETV1.png" group-title="其他",CETV-1 高清
-http://192.168.10.1:5678/sxg.php?id=CETV-1H264_4000
-#EXTINF:-1,tvg-id="凤凰中文" tvg-name="凤凰中文" tvg-logo="https://epg.112114.xyz/logo/凤凰中文.png" group-title="香港",凤凰中文 高清
-http://192.168.10.1:5678/sxg.php?id=test1_4000
-#EXTINF:-1,tvg-id="凤凰资讯" tvg-name="凤凰资讯" tvg-logo="https://epg.112114.xyz/logo/凤凰资讯.png" group-title="香港",凤凰资讯 高清
-http://192.168.10.1:5678/sxg.php?id=test2_4000
-#EXTINF:-1,tvg-id="黑龙江卫视" tvg-name="黑龙江卫视" tvg-logo="https://epg.112114.xyz/logo/黑龙江卫视.png" group-title="卫视",黑龙江卫视 高清
-http://192.168.10.1:5678/sxg.php?id=hljwsH265_4000
-#EXTINF:-1,tvg-id="吉林卫视" tvg-name="吉林卫视" tvg-logo="https://epg.112114.xyz/logo/吉林卫视.png" group-title="卫视",吉林卫视 高清
-http://192.168.10.1:5678/sxg.php?id=jlwsH265_4000
-#EXTINF:-1,tvg-id="辽宁卫视" tvg-name="辽宁卫视" tvg-logo="https://epg.112114.xyz/logo/辽宁卫视.png" group-title="卫视",辽宁卫视 高清
-http://192.168.10.1:5678/sxg.php?id=lnwsHDH264_4000
-#EXTINF:-1,tvg-id="北京卫视" tvg-name="北京卫视" tvg-logo="https://epg.112114.xyz/logo/北京卫视.png" group-title="卫视",北京卫视 高清
-http://192.168.10.1:5678/sxg.php?id=bjwsH265_4000
-#EXTINF:-1,tvg-id="天津卫视" tvg-name="天津卫视" tvg-logo="https://epg.112114.xyz/logo/天津卫视.png" group-title="卫视",天津卫视 高清
-http://192.168.10.1:5678/sxg.php?id=tjwsH265_4000
-#EXTINF:-1,tvg-id="河南卫视" tvg-name="河南卫视" tvg-logo="https://epg.112114.xyz/logo/河南卫视.png" group-title="卫视",河南卫视 高清
-http://192.168.10.1:5678/sxg.php?id=hnws35_4000
-#EXTINF:-1,tvg-id="梨园" tvg-name="梨园" tvg-logo="https://epg.112114.xyz/logo/梨园.png" group-title="其他",梨园频道 高清
-http://192.168.10.1:5678/sxg.php?id=ly_4000
-#EXTINF:-1,tvg-id="武术世界" tvg-name="武术世界" tvg-logo="https://epg.112114.xyz/logo/武术世界.png" group-title="其他",武术世界 高清
-http://192.168.10.1:5678/sxg.php?id=wssj_4000
-#EXTINF:-1,tvg-id="山东卫视" tvg-name="山东卫视" tvg-logo="https://epg.112114.xyz/logo/山东卫视.png" group-title="卫视",山东卫视 高清
-http://192.168.10.1:5678/sxg.php?id=sdwsH265_4000
-#EXTINF:-1,tvg-id="江苏卫视" tvg-name="江苏卫视" tvg-logo="https://epg.112114.xyz/logo/江苏卫视.png" group-title="卫视",江苏卫视 高清
-http://192.168.10.1:5678/sxg.php?id=jswsH265_4000
-#EXTINF:-1,tvg-id="东方卫视" tvg-name="东方卫视" tvg-logo="https://epg.112114.xyz/logo/东方卫视.png" group-title="卫视",东方卫视 高清
-http://192.168.10.1:5678/sxg.php?id=dfwsH265_4000
-#EXTINF:-1,tvg-id="安徽卫视" tvg-name="安徽卫视" tvg-logo="https://epg.112114.xyz/logo/安徽卫视.png" group-title="卫视",安徽卫视 高清
-http://192.168.10.1:5678/sxg.php?id=ahwsH265_4000
-#EXTINF:-1,tvg-id="湖北卫视" tvg-name="湖北卫视" tvg-logo="https://epg.112114.xyz/logo/湖北卫视.png" group-title="卫视",湖北卫视 高清
-http://192.168.10.1:5678/sxg.php?id=hbwsH265_4000
-#EXTINF:-1,tvg-id="湖南卫视" tvg-name="湖南卫视" tvg-logo="https://epg.112114.xyz/logo/湖南卫视.png" group-title="卫视",湖南卫视 高清
-http://192.168.10.1:5678/sxg.php?id=hnwsH265_4000
-#EXTINF:-1,tvg-id="金鹰纪实" tvg-name="金鹰纪实" tvg-logo="https://epg.112114.xyz/logo/金鹰纪实.png" group-title="其他",金鹰纪实 高清
-http://192.168.10.1:5678/sxg.php?id=jyjsHDH265_4000
-#EXTINF:-1,tvg-id="快乐垂钓" tvg-name="快乐垂钓" tvg-logo="https://epg.112114.xyz/logo/快乐垂钓.png" group-title="其他",快乐垂钓 高清
-http://192.168.10.1:5678/sxg.php?id=fyzqklcdHDH265_4000
-#EXTINF:-1,tvg-id="浙江卫视" tvg-name="浙江卫视" tvg-logo="https://epg.112114.xyz/logo/浙江卫视.png" group-title="卫视",浙江卫视 高清
-http://192.168.10.1:5678/sxg.php?id=zjwsH265_4000
-#EXTINF:-1,tvg-id="江西卫视" tvg-name="江西卫视" tvg-logo="https://epg.112114.xyz/logo/江西卫视.png" group-title="卫视",江西卫视 高清
-http://192.168.10.1:5678/sxg.php?id=jxwsH265_4000
-#EXTINF:-1,tvg-id="东南卫视" tvg-name="东南卫视" tvg-logo="https://epg.112114.xyz/logo/东南卫视.png" group-title="卫视",东南卫视 高清
-http://192.168.10.1:5678/sxg.php?id=dnwsfjwsH265_4000
-#EXTINF:-1,tvg-id="四川卫视" tvg-name="四川卫视" tvg-logo="https://epg.112114.xyz/logo/四川卫视.png" group-title="卫视",四川卫视 高清
-http://192.168.10.1:5678/sxg.php?id=scwsH265_4000
-#EXTINF:-1,tvg-id="重庆卫视" tvg-name="重庆卫视" tvg-logo="https://epg.112114.xyz/logo/重庆卫视.png" group-title="卫视",重庆卫视 高清
-http://192.168.10.1:5678/sxg.php?id=cqwsH265_4000
-#EXTINF:-1,tvg-id="贵州卫视" tvg-name="贵州卫视" tvg-logo="https://epg.112114.xyz/logo/贵州卫视.png" group-title="卫视",贵州卫视 高清
-http://192.168.10.1:5678/sxg.php?id=gzwsH265_4000
-#EXTINF:-1,tvg-id="广东卫视" tvg-name="广东卫视" tvg-logo="https://epg.112114.xyz/logo/广东卫视.png" group-title="卫视",广东卫视 高清
-http://192.168.10.1:5678/sxg.php?id=gdwsH265_4000
-#EXTINF:-1,tvg-id="深圳卫视" tvg-name="深圳卫视" tvg-logo="https://epg.112114.xyz/logo/深圳卫视.png" group-title="卫视",深圳卫视 高清
-http://192.168.10.1:5678/sxg.php?id=szwsH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川文化旅游.png" group-title="四川",四川文化旅游 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-2-H265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川经济.png" group-title="四川",四川经济 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-3-H265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川新闻.png" group-title="四川",四川新闻 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-4H265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川影视文艺.png" group-title="四川",四川影视文艺 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-5-scysH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川妇女儿童.png" group-title="四川",四川妇女儿童 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-7-_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川科教.png" group-title="四川",四川科教 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-ggSCTV-8_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川乡村.png" group-title="四川",四川乡村 高清
-http://192.168.10.1:5678/sxg.php?id=SCTV-kjSCTV-9-_4000
-#EXTINF:-1,tvg-id="峨嵋电影" tvg-name="峨嵋电影" tvg-logo="https://epg.112114.xyz/logo/峨嵋电影.png" group-title="四川",四川峨嵋电影 高清
-http://192.168.10.1:5678/sxg.php?id=emdygqH265_4000
 #EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/4K电影4K.png" group-title="其他",4K超高清电影 4K
 http://192.168.10.1:5678/sxg.php?id=emdy4k_8000
-#EXTINF:-1,tvg-id="CHC家庭影院" tvg-name="CHC家庭影院" tvg-logo="https://epg.112114.xyz/logo/CHC家庭影院.png" group-title="其他",CHC家庭影院 高清
-http://192.168.10.1:5678/sxg.php?id=jbtygqCHCjtyyH265_4000
-#EXTINF:-1,tvg-id="CHC高清电影" tvg-name="CHC高清电影" tvg-logo="https://epg.112114.xyz/logo/CHC高清电影.png" group-title="其他",CHC高清电影 高清
-http://192.168.10.1:5678/sxg.php?id=lnwsCHC-HDH265_4000
-#EXTINF:-1,tvg-id="CHC动作电影" tvg-name="CHC动作电影" tvg-logo="https://epg.112114.xyz/logo/CHC动作电影.png" group-title="其他",CHC动作电影 高清
-http://192.168.10.1:5678/sxg.php?id=wqCHCdzdyH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CBN幸福剧场.png" group-title="其他",CBN幸福剧场 高清
-http://192.168.10.1:5678/sxg.php?id=xfjc_4000
-#EXTINF:-1,tvg-id="每日影院" tvg-name="每日影院" tvg-logo="https://epg.112114.xyz/logo/每日影院.png" group-title="其他",CBN每日影院 高清
-http://192.168.10.1:5678/sxg.php?id=mryy_4000
-#EXTINF:-1,tvg-id="幸福娱乐" tvg-name="幸福娱乐" tvg-logo="https://epg.112114.xyz/logo/幸福娱乐.png" group-title="其他",CBN幸福娱乐 高清
-http://192.168.10.1:5678/sxg.php?id=xfyl_4000
-#EXTINF:-1,tvg-id="风尚生活" tvg-name="风尚生活" tvg-logo="https://epg.112114.xyz/logo/风尚生活.png" group-title="其他",CBN风尚生活 高清
-http://192.168.10.1:5678/sxg.php?id=fssh_4000
-#EXTINF:-1,tvg-id="新视觉" tvg-name="新视觉" tvg-logo="https://epg.112114.xyz/logo/新视觉.png" group-title="其他",新视觉 高清
-http://192.168.10.1:5678/sxg.php?id=ycxsjH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐游.png" group-title="其他",乐游 高清
-http://192.168.10.1:5678/sxg.php?id=qjs-HDH265_4000
-#EXTINF:-1,tvg-id="SITV都市剧场" tvg-name="SITV都市剧场" tvg-logo="https://epg.112114.xyz/logo/SITV都市剧场.png" group-title="其他",都市剧场 高清
-http://192.168.10.1:5678/sxg.php?id=yxfydsjcHDH265_4000
-#EXTINF:-1,tvg-id="动漫秀场" tvg-name="动漫秀场" tvg-logo="https://epg.112114.xyz/logo/动漫秀场.png" group-title="其他",动漫秀场 高清
-http://192.168.10.1:5678/sxg.php?id=yybb-dmxc-H265_4000
-#EXTINF:-1,tvg-id="SITV劲爆体育" tvg-name="SITV劲爆体育" tvg-logo="https://epg.112114.xyz/logo/SITV劲爆体育.png" group-title="其他",劲爆体育 高清
-http://192.168.10.1:5678/sxg.php?id=lqhxjcHDH265_4000
-#EXTINF:-1,tvg-id="魅力足球" tvg-name="魅力足球" tvg-logo="https://epg.112114.xyz/logo/魅力足球.png" group-title="其他",魅力足球 高清
-http://192.168.10.1:5678/sxg.php?id=mlyy_4000
-#EXTINF:-1,tvg-id="生活时尚" tvg-name="生活时尚" tvg-logo="https://epg.112114.xyz/logo/生活时尚.png" group-title="其他",生活时尚 高清
-http://192.168.10.1:5678/sxg.php?id=shssH265_4000
-#EXTINF:-1,tvg-id="SITV法治天地" tvg-name="SITV法治天地" tvg-logo="https://epg.112114.xyz/logo/SITV法治天地.png" group-title="其他",法治天地 高清
-http://192.168.10.1:5678/sxg.php?id=fztx_4000
-#EXTINF:-1,tvg-id="MAX极速汽车" tvg-name="MAX极速汽车" tvg-logo="https://epg.112114.xyz/logo/MAX极速汽车.png" group-title="其他",极速汽车 高清
-http://192.168.10.1:5678/sxg.php?id=jsqcH265_4000
-#EXTINF:-1,tvg-id="欢笑剧场" tvg-name="欢笑剧场" tvg-logo="https://epg.112114.xyz/logo/欢笑剧场.png" group-title="其他",欢笑剧场 4K
+#EXTINF:-1,tvg-id="欢笑剧场" tvg-name="欢笑剧场" tvg-logo="https://epg.112114.xyz/logo/欢笑剧场.png" group-title="其他",欢笑剧场4K
 http://192.168.10.1:5678/sxg.php?id=hxjc-4k_8000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/甘孜综合.png" group-title="其他",甘孜综合 高清
-http://192.168.10.1:5678/sxg.php?id=gzxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/剑阁综合.png" group-title="其他",剑阁综合 高清
-http://192.168.10.1:5678/sxg.php?id=jgxwzhH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/峨眉综合.png" group-title="其他",峨眉综合 高清
-http://192.168.10.1:5678/sxg.php?id=emsxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/平昌综合.png" group-title="其他",平昌综合 高清
-http://192.168.10.1:5678/sxg.php?id=pcxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宣汉综合.png" group-title="其他",宣汉综合 高清
-http://192.168.10.1:5678/sxg.php?id=xhxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/新都综合.png" group-title="其他",新都综合 高清
-http://192.168.10.1:5678/sxg.php?id=xdzhpd_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/巴州电视.png" group-title="其他",巴州电视 高清
-http://192.168.10.1:5678/sxg.php?id=bzxw_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/利州综合.png" group-title="其他",利州综合 高清
-http://192.168.10.1:5678/sxg.php?id=lzxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/彭州综合.png" group-title="其他",彭州综合 高清
-http://192.168.10.1:5678/sxg.php?id=pzxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/彭山综合.png" group-title="其他",彭山综合 高清
-http://192.168.10.1:5678/sxg.php?id=pszh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/船山综合.png" group-title="其他",船山综合 高清
-http://192.168.10.1:5678/sxg.php?id=csxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/屏山综合.png" group-title="其他",屏山综合 高清
-http://192.168.10.1:5678/sxg.php?id=psxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南充综合.png" group-title="其他",南充综合 高清
-http://192.168.10.1:5678/sxg.php?id=ncxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/西充综合.png" group-title="其他",西充综合 高清
-http://192.168.10.1:5678/sxg.php?id=xczh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/朝天综合.png" group-title="其他",朝天综合 高清
-http://192.168.10.1:5678/sxg.php?id=ctxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宝兴综合.png" group-title="其他",宝兴综合 高清
-http://192.168.10.1:5678/sxg.php?id=bxdst_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/昭化综合.png" group-title="其他",昭化综合 高清
-http://192.168.10.1:5678/sxg.php?id=zhxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/北川综合.png" group-title="其他",北川综合 高清
-http://192.168.10.1:5678/sxg.php?id=bcxwHD_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/沐川综合.png" group-title="其他",沐川综合 高清
-http://192.168.10.1:5678/sxg.php?id=mcxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/通江综合.png" group-title="其他",通江综合 高清
-http://192.168.10.1:5678/sxg.php?id=tjxwH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/浦江综合.png" group-title="其他",浦江综合 高清
-http://192.168.10.1:5678/sxg.php?id=pjxw_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/米易综合.png" group-title="其他",米易综合 高清
-http://192.168.10.1:5678/sxg.php?id=myxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/马边综合.png" group-title="其他",马边综合 高清
-http://192.168.10.1:5678/sxg.php?id=mbxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/涪城综合.png" group-title="其他",涪城综合 高清
-http://192.168.10.1:5678/sxg.php?id=fcgq_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/荣县综合.png" group-title="其他",荣县综合 高清
-http://192.168.10.1:5678/sxg.php?id=rxzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/青神综合.png" group-title="其他",青神综合 高清
-http://192.168.10.1:5678/sxg.php?id=qszh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/越西综合.png" group-title="其他",越西综合 高清
-http://192.168.10.1:5678/sxg.php?id=yxt_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/自贡综合.png" group-title="其他",自贡综合 高清
-http://192.168.10.1:5678/sxg.php?id=zgxw_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/自贡公共.png" group-title="其他",自贡公共 高清
-http://192.168.10.1:5678/sxg.php?id=zggg_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/恩阳新闻.png" group-title="其他",恩阳新闻 高清
-http://192.168.10.1:5678/sxg.php?id=eyxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/天泉新闻.png" group-title="其他",天泉新闻 高清
-http://192.168.10.1:5678/sxg.php?id=tqzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/珙县新闻.png" group-title="其他",珙县新闻 高清
-http://192.168.10.1:5678/sxg.php?id=gxzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/金口河综合.png" group-title="其他",金口河综合 高清
-http://192.168.10.1:5678/sxg.php?id=jkhdst_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/青白江综合.png" group-title="其他",青白江综合 高清
-http://192.168.10.1:5678/sxg.php?id=qbjxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/大邑电视台.png" group-title="其他",大邑电视台 高清
-http://192.168.10.1:5678/sxg.php?id=dyytH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/兴文电视台.png" group-title="其他",兴文电视台 高清
-http://192.168.10.1:5678/sxg.php?id=xwt_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/荥经电视台.png" group-title="其他",荥经电视台 高清
-http://192.168.10.1:5678/sxg.php?id=xjdst_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南江电视台.png" group-title="其他",南江电视台 高清
-http://192.168.10.1:5678/sxg.php?id=njxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/盐边电视台.png" group-title="其他",盐边电视台 高清
-http://192.168.10.1:5678/sxg.php?id=ybtgq_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/金堂电视台.png" group-title="其他",金堂电视台 高清
-http://192.168.10.1:5678/sxg.php?id=jtzhpd_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都高新区.png" group-title="其他",成都高新区 高清
-http://192.168.10.1:5678/sxg.php?id=cdgxdstgq_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都新闻综合.png" group-title="其他",成都新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=CDTV-1_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都每日购物.png" group-title="其他",成都每日购物 高清
-http://192.168.10.1:5678/sxg.php?id=mrgw_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/什邡新闻综合.png" group-title="其他",什邡新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=sfx_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/开江新闻综合.png" group-title="其他",开江新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=kjxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/夹江新闻综合.png" group-title="其他",夹江新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=jjxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/中江新闻综合.png" group-title="其他",中江新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=zjxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/攀钢新闻综合.png" group-title="其他",攀钢新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=pgxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/旺苍新闻综合.png" group-title="其他",旺苍新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=wcxwzhH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/普格新闻综合.png" group-title="其他",普格新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=pgxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/大英新闻综合.png" group-title="其他",大英新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=dyxwzhH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/洪雅新闻综合.png" group-title="其他",洪雅新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=hyzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/渠县新闻综合.png" group-title="其他",渠县新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=qxxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/郫县新闻综合.png" group-title="其他",郫县新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=pxds1_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/蓬溪新闻综合.png" group-title="其他",蓬溪新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=pxxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/资阳新闻综合.png" group-title="其他",资阳新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=zyxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达川新闻综合.png" group-title="其他",达川新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=dcxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/凉山新闻综合.png" group-title="其他",凉山新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=lsxwHDH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/凉山彝语综合.png" group-title="其他",凉山彝语综合 高清
-http://192.168.10.1:5678/sxg.php?id=yyzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/攀枝花新闻综合.png" group-title="其他",攀枝花新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=pzhytH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/绵阳新闻综合.png" group-title="其他",绵阳新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=myytH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/绵阳科技.png" group-title="其他",绵阳科技 高清
-http://192.168.10.1:5678/sxg.php?id=myetH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州新闻综合.png" group-title="其他",达州新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=dzxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州公共.png" group-title="其他",达州公共 高清
-http://192.168.10.1:5678/sxg.php?id=dzgg_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州通川.png" group-title="其他",达州通川 高清
-http://192.168.10.1:5678/sxg.php?id=tcq_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雅安新闻综合.png" group-title="其他",雅安新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=yazh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雅安公共.png" group-title="其他",雅安公共 高清
-http://192.168.10.1:5678/sxg.php?id=yagg_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐山新闻综合.png" group-title="其他",乐山新闻综合 高清
-http://192.168.10.1:5678/sxg.php?id=lsxwzh_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐山公共.png" group-title="其他",乐山公共 高清
-http://192.168.10.1:5678/sxg.php?id=lsggpd_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广元综合.png" group-title="其他",广元综合 高清
-http://192.168.10.1:5678/sxg.php?id=gyzhH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广元文化生活.png" group-title="其他",广元文化生活 高清
-http://192.168.10.1:5678/sxg.php?id=gyggH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/巴中综合.png" group-title="其他",巴中综合 高清
-http://192.168.10.1:5678/sxg.php?id=bzytH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/巴中文旅生活.png" group-title="其他",巴中文旅生活 高清
-http://192.168.10.1:5678/sxg.php?id=bzetH264_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/高县1.png" group-title="其他",高县-1 高清
-http://192.168.10.1:5678/sxg.php?id=gxt_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/新津.png" group-title="其他",新津 高清
-http://192.168.10.1:5678/sxg.php?id=xjzh_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/崇州.png" group-title="其他",崇州 高清
-http://192.168.10.1:5678/sxg.php?id=czyt_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/木里.png" group-title="其他",木里 高清
-http://192.168.10.1:5678/sxg.php?id=mltHD_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/岳池.png" group-title="其他",岳池 高清
-http://192.168.10.1:5678/sxg.php?id=ycxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/万源.png" group-title="其他",万源 高清
-http://192.168.10.1:5678/sxg.php?id=wyxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雁江.png" group-title="其他",雁江 高清
-http://192.168.10.1:5678/sxg.php?id=yjxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/五通桥.png" group-title="其他",五通桥 高清
-http://192.168.10.1:5678/sxg.php?id=wtqxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/沙湾融媒.png" group-title="其他",沙湾融媒 高清
-http://192.168.10.1:5678/sxg.php?id=swxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/精品导视.png" group-title="其他",精品导视 高清
-http://192.168.10.1:5678/sxg.php?id=jpdsH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/川网导视.png" group-title="其他",川网导视 高清
-http://192.168.10.1:5678/sxg.php?id=cwdsHDH264_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/央广购物.png" group-title="其他",央广购物 高清
-http://192.168.10.1:5678/sxg.php?id=yggwgq_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/聚鲨环球精选.png" group-title="其他",聚鲨环球精选 高清
-http://192.168.10.1:5678/sxg.php?id=jshqjxHD_4000
-#EXTINF:-1,tvg-id="中国天气" tvg-name="中国天气" tvg-logo="https://epg.112114.xyz/logo/中国天气.png" group-title="其他",中国天气 标清
-http://192.168.10.1:5678/sxg.php?id=zgqx_4000
-#EXTINF:-1,tvg-id="摄影" tvg-name="摄影" tvg-logo="https://epg.112114.xyz/logo/摄影.png" group-title="其他",摄影频道 标清
-http://192.168.10.1:5678/sxg.php?id=sy_4000
-#EXTINF:-1,tvg-id="天元围棋" tvg-name="天元围棋" tvg-logo="https://epg.112114.xyz/logo/天元围棋.png" group-title="其他",天元围棋 标清
-http://192.168.10.1:5678/sxg.php?id=tywq_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四海钓鱼.png" group-title="其他",四海钓鱼 标清
-http://192.168.10.1:5678/sxg.php?id=shdy_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/先锋乒羽.png" group-title="其他",先锋乒羽 标清
-http://192.168.10.1:5678/sxg.php?id=xfpy_4000
-#EXTINF:-1,tvg-id="家庭理财" tvg-name="家庭理财" tvg-logo="https://epg.112114.xyz/logo/家庭理财.png" group-title="其他",家庭理财 标清
-http://192.168.10.1:5678/sxg.php?id=jtlc_4000
-#EXTINF:-1,tvg-id="湖南金鹰卡通" tvg-name="湖南金鹰卡通" tvg-logo="https://epg.112114.xyz/logo/湖南金鹰卡通.png" group-title="其他",金鹰卡通 标清
-http://192.168.10.1:5678/sxg.php?id=jykt_2000
-#EXTINF:-1,tvg-id="嘉佳卡通" tvg-name="嘉佳卡通" tvg-logo="https://epg.112114.xyz/logo/嘉佳卡通.png" group-title="其他",嘉佳卡通 标清
-http://192.168.10.1:5678/sxg.php?id=jjkt_2000
-#EXTINF:-1,tvg-id="卡酷少儿" tvg-name="卡酷少儿" tvg-logo="https://epg.112114.xyz/logo/卡酷少儿.png" group-title="其他",卡酷少儿 标清
-http://192.168.10.1:5678/sxg.php?id=kkkt_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/纪实科教.png" group-title="其他",纪实科教 标清
-http://192.168.10.1:5678/sxg.php?id=bjjs_2000
-#EXTINF:-1,tvg-id="SITV七彩戏剧" tvg-name="SITV七彩戏剧" tvg-logo="https://epg.112114.xyz/logo/SITV七彩戏剧.png" group-title="其他",七彩戏剧 标清
-http://192.168.10.1:5678/sxg.php?id=qcxj_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/证劵服务.png" group-title="其他",证劵服务 标清
-http://192.168.10.1:5678/sxg.php?id=jz_2000
-#EXTINF:-1,tvg-id="老故事" tvg-name="老故事" tvg-logo="https://epg.112114.xyz/logo/老故事.png" group-title="央视",中央新影-老故事 标清
-http://192.168.10.1:5678/sxg.php?id=lgs_2000
-#EXTINF:-1,tvg-id="中学生" tvg-name="中学生" tvg-logo="https://epg.112114.xyz/logo/中学生.png" group-title="央视",中央新影-中学生 标清
-http://192.168.10.1:5678/sxg.php?id=zxs_4000
-#EXTINF:-1,tvg-id="发现之旅" tvg-name="发现之旅" tvg-logo="https://epg.112114.xyz/logo/发现之旅.png" group-title="央视",中央新影-发现之旅 标清
-http://192.168.10.1:5678/sxg.php?id=fxzl_2000
-#EXTINF:-1,tvg-id="广西卫视" tvg-name="广西卫视" tvg-logo="https://epg.112114.xyz/logo/广西卫视.png" group-title="卫视",广西卫视 标清
-http://192.168.10.1:5678/sxg.php?id=gxws_4000
-#EXTINF:-1,tvg-id="陕西卫视" tvg-name="陕西卫视" tvg-logo="https://epg.112114.xyz/logo/陕西卫视.png" group-title="卫视",陕西卫视 标清
-http://192.168.10.1:5678/sxg.php?id=sxws_4000
-#EXTINF:-1,tvg-id="山西卫视" tvg-name="山西卫视" tvg-logo="https://epg.112114.xyz/logo/山西卫视.png" group-title="卫视",山西卫视 标清
-http://192.168.10.1:5678/sxg.php?id=sxws42_4000
-#EXTINF:-1,tvg-id="云南卫视" tvg-name="云南卫视" tvg-logo="https://epg.112114.xyz/logo/云南卫视.png" group-title="卫视",云南卫视 标清
-http://192.168.10.1:5678/sxg.php?id=ynws_4000
-#EXTINF:-1,tvg-id="甘肃卫视" tvg-name="甘肃卫视" tvg-logo="https://epg.112114.xyz/logo/甘肃卫视.png" group-title="卫视",甘肃卫视 标清
-http://192.168.10.1:5678/sxg.php?id=gsws_4000
-#EXTINF:-1,tvg-id="西藏卫视" tvg-name="西藏卫视" tvg-logo="https://epg.112114.xyz/logo/西藏卫视.png" group-title="卫视",西藏卫视 标清
-http://192.168.10.1:5678/sxg.php?id=xzwsH264_2000
-#EXTINF:-1,tvg-id="海南卫视" tvg-name="海南卫视" tvg-logo="https://epg.112114.xyz/logo/海南卫视.png" group-title="卫视",海南卫视 标清
-http://192.168.10.1:5678/sxg.php?id=hnws_4000
-#EXTINF:-1,tvg-id="兵团卫视" tvg-name="兵团卫视" tvg-logo="https://epg.112114.xyz/logo/兵团卫视.png" group-title="卫视",兵团卫视 标清
+#EXTINF:-1,tvg-id="凤凰中文" tvg-name="凤凰中文" tvg-logo="https://epg.112114.xyz/logo/凤凰中文.png" group-title="香港",凤凰中文
+http://192.168.10.1:5678/sxg.php?id=test1_4000
+#EXTINF:-1,tvg-id="凤凰资讯" tvg-name="凤凰资讯" tvg-logo="https://epg.112114.xyz/logo/凤凰资讯.png" group-title="香港",凤凰资讯
+http://192.168.10.1:5678/sxg.php?id=test2_4000
+#EXTINF:-1,tvg-id="安徽卫视" tvg-name="安徽卫视" tvg-logo="https://epg.112114.xyz/logo/安徽卫视.png" group-title="卫视",安徽卫视
+http://192.168.10.1:5678/sxg.php?id=ahwsH265_4000
+#EXTINF:-1,tvg-id="北京卫视" tvg-name="北京卫视" tvg-logo="https://epg.112114.xyz/logo/北京卫视.png" group-title="卫视",北京卫视
+http://192.168.10.1:5678/sxg.php?id=bjwsH265_4000
+#EXTINF:-1,tvg-id="兵团卫视" tvg-name="兵团卫视" tvg-logo="https://epg.112114.xyz/logo/兵团卫视.png" group-title="卫视",兵团卫视
 http://192.168.10.1:5678/sxg.php?id=btws_4000
-#EXTINF:-1,tvg-id="康巴卫视" tvg-name="康巴卫视" tvg-logo="https://epg.112114.xyz/logo/康巴卫视.png" group-title="卫视",康巴卫视 标清
+#EXTINF:-1,tvg-id="重庆卫视" tvg-name="重庆卫视" tvg-logo="https://epg.112114.xyz/logo/重庆卫视.png" group-title="卫视",重庆卫视
+http://192.168.10.1:5678/sxg.php?id=cqwsH265_4000
+#EXTINF:-1,tvg-id="东方卫视" tvg-name="东方卫视" tvg-logo="https://epg.112114.xyz/logo/东方卫视.png" group-title="卫视",东方卫视
+http://192.168.10.1:5678/sxg.php?id=dfwsH265_4000
+#EXTINF:-1,tvg-id="东南卫视" tvg-name="东南卫视" tvg-logo="https://epg.112114.xyz/logo/东南卫视.png" group-title="卫视",东南卫视
+http://192.168.10.1:5678/sxg.php?id=dnwsfjwsH265_4000
+#EXTINF:-1,tvg-id="甘肃卫视" tvg-name="甘肃卫视" tvg-logo="https://epg.112114.xyz/logo/甘肃卫视.png" group-title="卫视",甘肃卫视
+http://192.168.10.1:5678/sxg.php?id=gsws_4000
+#EXTINF:-1,tvg-id="广东卫视" tvg-name="广东卫视" tvg-logo="https://epg.112114.xyz/logo/广东卫视.png" group-title="卫视",广东卫视
+http://192.168.10.1:5678/sxg.php?id=gdwsH265_4000
+#EXTINF:-1,tvg-id="广西卫视" tvg-name="广西卫视" tvg-logo="https://epg.112114.xyz/logo/广西卫视.png" group-title="卫视",广西卫视
+http://192.168.10.1:5678/sxg.php?id=gxws_4000
+#EXTINF:-1,tvg-id="贵州卫视" tvg-name="贵州卫视" tvg-logo="https://epg.112114.xyz/logo/贵州卫视.png" group-title="卫视",贵州卫视
+http://192.168.10.1:5678/sxg.php?id=gzwsH265_4000
+#EXTINF:-1,tvg-id="海南卫视" tvg-name="海南卫视" tvg-logo="https://epg.112114.xyz/logo/海南卫视.png" group-title="卫视",海南卫视
+http://192.168.10.1:5678/sxg.php?id=hnws_4000
+#EXTINF:-1,tvg-id="河南卫视" tvg-name="河南卫视" tvg-logo="https://epg.112114.xyz/logo/河南卫视.png" group-title="卫视",河南卫视
+http://192.168.10.1:5678/sxg.php?id=hnws35_4000
+#EXTINF:-1,tvg-id="黑龙江卫视" tvg-name="黑龙江卫视" tvg-logo="https://epg.112114.xyz/logo/黑龙江卫视.png" group-title="卫视",黑龙江卫视
+http://192.168.10.1:5678/sxg.php?id=hljwsH265_4000
+#EXTINF:-1,tvg-id="湖北卫视" tvg-name="湖北卫视" tvg-logo="https://epg.112114.xyz/logo/湖北卫视.png" group-title="卫视",湖北卫视
+http://192.168.10.1:5678/sxg.php?id=hbwsH265_4000
+#EXTINF:-1,tvg-id="湖南卫视" tvg-name="湖南卫视" tvg-logo="https://epg.112114.xyz/logo/湖南卫视.png" group-title="卫视",湖南卫视
+http://192.168.10.1:5678/sxg.php?id=hnwsH265_4000
+#EXTINF:-1,tvg-id="吉林卫视" tvg-name="吉林卫视" tvg-logo="https://epg.112114.xyz/logo/吉林卫视.png" group-title="卫视",吉林卫视
+http://192.168.10.1:5678/sxg.php?id=jlwsH265_4000
+#EXTINF:-1,tvg-id="江苏卫视" tvg-name="江苏卫视" tvg-logo="https://epg.112114.xyz/logo/江苏卫视.png" group-title="卫视",江苏卫视
+http://192.168.10.1:5678/sxg.php?id=jswsH265_4000
+#EXTINF:-1,tvg-id="江西卫视" tvg-name="江西卫视" tvg-logo="https://epg.112114.xyz/logo/江西卫视.png" group-title="卫视",江西卫视
+http://192.168.10.1:5678/sxg.php?id=jxwsH265_4000
+#EXTINF:-1,tvg-id="康巴卫视" tvg-name="康巴卫视" tvg-logo="https://epg.112114.xyz/logo/康巴卫视.png" group-title="卫视",康巴卫视
 http://192.168.10.1:5678/sxg.php?id=kbwsH264_2000
-#EXTINF:-1,tvg-id="内蒙古卫视" tvg-name="内蒙古卫视" tvg-logo="https://epg.112114.xyz/logo/内蒙古卫视.png" group-title="卫视",内蒙古卫视 标清
+#EXTINF:-1,tvg-id="辽宁卫视" tvg-name="辽宁卫视" tvg-logo="https://epg.112114.xyz/logo/辽宁卫视.png" group-title="卫视",辽宁卫视
+http://192.168.10.1:5678/sxg.php?id=lnwsHDH264_4000
+#EXTINF:-1,tvg-id="内蒙古卫视" tvg-name="内蒙古卫视" tvg-logo="https://epg.112114.xyz/logo/内蒙古卫视.png" group-title="卫视",内蒙古卫视
 http://192.168.10.1:5678/sxg.php?id=nmgws_4000
-#EXTINF:-1,tvg-id="山东教育卫视" tvg-name="山东教育卫视" tvg-logo="https://epg.112114.xyz/logo/山东教育卫视.png" group-title="卫视",山东教育卫视 标清
+#EXTINF:-1,tvg-id="山东教育卫视" tvg-name="山东教育卫视" tvg-logo="https://epg.112114.xyz/logo/山东教育卫视.png" group-title="卫视",山东教育卫视
 http://192.168.10.1:5678/sxg.php?id=sdjy_4000
-#EXTINF:-1,tvg-id="财富天下" tvg-name="财富天下" tvg-logo="https://epg.112114.xyz/logo/财富天下.png" group-title="江苏",江苏财富天下 标清
-http://192.168.10.1:5678/sxg.php?id=cftx_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都经济资讯.png" group-title="其他",成都经济资讯 标清
-http://192.168.10.1:5678/sxg.php?id=CDTV-2_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都都市生活.png" group-title="其他",成都都市生活 标清
-http://192.168.10.1:5678/sxg.php?id=CDTV-3_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都影视文艺.png" group-title="其他",成都影视文艺 标清
-http://192.168.10.1:5678/sxg.php?id=CDTV-4_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都公共频道.png" group-title="其他",成都公共频道 标清
-http://192.168.10.1:5678/sxg.php?id=CDTV-5_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/川广融媒.png" group-title="其他",川广融媒 标清
-http://192.168.10.1:5678/sxg.php?id=cgrh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/丹棱综合.png" group-title="其他",丹棱综合 标清
-http://192.168.10.1:5678/sxg.php?id=dlxwzhH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南溪综合.png" group-title="其他",南溪综合 标清
-http://192.168.10.1:5678/sxg.php?id=nxt_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南部综合.png" group-title="其他",南部综合 标清
-http://192.168.10.1:5678/sxg.php?id=nbxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/安居综合.png" group-title="其他",安居综合 标清
-http://192.168.10.1:5678/sxg.php?id=ajxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/富顺综合.png" group-title="其他",富顺综合 标清
-http://192.168.10.1:5678/sxg.php?id=fszh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广汉综合.png" group-title="其他",广汉综合 标清
-http://192.168.10.1:5678/sxg.php?id=ghxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/武胜综合.png" group-title="其他",武胜综合 标清
-http://192.168.10.1:5678/sxg.php?id=wsxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/汉源综合.png" group-title="其他",汉源综合 标清
-http://192.168.10.1:5678/sxg.php?id=hyxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/阆中综合.png" group-title="其他",阆中综合 标清
-http://192.168.10.1:5678/sxg.php?id=lzxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雅安雨城.png" group-title="其他",雅安雨城 标清
-http://192.168.10.1:5678/sxg.php?id=ycpd_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/青川综合.png" group-title="其他",青川综合 标清
-http://192.168.10.1:5678/sxg.php?id=qcxwzhH265_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/龙泉综合.png" group-title="其他",龙泉综合 标清
-http://192.168.10.1:5678/sxg.php?id=lqxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宁南综合.png" group-title="其他",宁南综合 标清
-http://192.168.10.1:5678/sxg.php?id=nnt_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/普格综合.png" group-title="其他",普格综合 标清
-http://192.168.10.1:5678/sxg.php?id=pgt_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/冕宁综合.png" group-title="其他",冕宁综合 标清
-http://192.168.10.1:5678/sxg.php?id=mnxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/江油综合.png" group-title="其他",江油综合 标清
-http://192.168.10.1:5678/sxg.php?id=jyxwHD_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/内江综合.png" group-title="其他",内江综合 标清
-http://192.168.10.1:5678/sxg.php?id=njzh_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/内江公共.png" group-title="其他",内江公共 标清
-http://192.168.10.1:5678/sxg.php?id=njgg_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/会理新闻.png" group-title="其他",会理新闻 标清
-http://192.168.10.1:5678/sxg.php?id=hlyt_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/井研新闻综合.png" group-title="其他",井研新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=jyxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/仪陇新闻综合.png" group-title="其他",仪陇新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=ylxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/合江新闻综合.png" group-title="其他",合江新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=hjxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宜宾新闻综合.png" group-title="其他",宜宾新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=ybx_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/犍为新闻综合.png" group-title="其他",犍为新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=qwxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/简阳新闻综合.png" group-title="其他",简阳新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=jyxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广安新闻综合.png" group-title="其他",广安新闻综合 标清
-http://192.168.10.1:5678/sxg.php?id=gaxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广安公共.png" group-title="其他",广安公共 标清
-http://192.168.10.1:5678/sxg.php?id=gagg_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/泸州综合.png" group-title="其他",泸州综合 标清
-http://192.168.10.1:5678/sxg.php?id=lzxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/泸州公共.png" group-title="其他",泸州公共 标清
-http://192.168.10.1:5678/sxg.php?id=lzgg_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广安区电视台.png" group-title="其他",广安区电视台 标清
-http://192.168.10.1:5678/sxg.php?id=gaqxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/德昌电视台.png" group-title="其他",德昌电视台 标清
-http://192.168.10.1:5678/sxg.php?id=dcxw_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/江安电视台.png" group-title="其他",江安电视台 标清
-http://192.168.10.1:5678/sxg.php?id=jat_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/叙永电视台.png" group-title="其他",叙永电视台 标清
-http://192.168.10.1:5678/sxg.php?id=xyxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/都江堰.png" group-title="其他",都江堰 标清
-http://192.168.10.1:5678/sxg.php?id=djyzh_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/纳溪1.png" group-title="其他",纳溪-1 标清
-http://192.168.10.1:5678/sxg.php?id=nxxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/蓬安1.png" group-title="其他",蓬安-1 标清
-http://192.168.10.1:5678/sxg.php?id=pazh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/绵竹.png" group-title="其他",绵竹 标清
-http://192.168.10.1:5678/sxg.php?id=mzxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/罗江.png" group-title="其他",罗江 标清
-http://192.168.10.1:5678/sxg.php?id=ljxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/营山.png" group-title="其他",营山 标清
-http://192.168.10.1:5678/sxg.php?id=ysxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/金牛.png" group-title="其他",金牛 标清
-http://192.168.10.1:5678/sxg.php?id=jnyx_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/邻水.png" group-title="其他",邻水 标清
-http://192.168.10.1:5678/sxg.php?id=lsxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/石棉.png" group-title="其他",石棉 标清
-http://192.168.10.1:5678/sxg.php?id=smxwzh_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/前锋.png" group-title="其他",前锋 标清
-http://192.168.10.1:5678/sxg.php?id=qfxw_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/喜德.png" group-title="其他",喜德 标清
-http://192.168.10.1:5678/sxg.php?id=xdxw_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CETV4.png" group-title="其他",CETV-4 标清
+#EXTINF:-1,tvg-id="山东卫视" tvg-name="山东卫视" tvg-logo="https://epg.112114.xyz/logo/山东卫视.png" group-title="卫视",山东卫视
+http://192.168.10.1:5678/sxg.php?id=sdwsH265_4000
+#EXTINF:-1,tvg-id="山西卫视" tvg-name="山西卫视" tvg-logo="https://epg.112114.xyz/logo/山西卫视.png" group-title="卫视",山西卫视
+http://192.168.10.1:5678/sxg.php?id=sxws42_4000
+#EXTINF:-1,tvg-id="陕西卫视" tvg-name="陕西卫视" tvg-logo="https://epg.112114.xyz/logo/陕西卫视.png" group-title="卫视",陕西卫视
+http://192.168.10.1:5678/sxg.php?id=sxws_4000
+#EXTINF:-1,tvg-id="深圳卫视" tvg-name="深圳卫视" tvg-logo="https://epg.112114.xyz/logo/深圳卫视.png" group-title="卫视",深圳卫视
+http://192.168.10.1:5678/sxg.php?id=szwsH265_4000
+#EXTINF:-1,tvg-id="四川卫视" tvg-name="四川卫视" tvg-logo="https://epg.112114.xyz/logo/四川卫视.png" group-title="卫视",四川卫视
+http://192.168.10.1:5678/sxg.php?id=scwsH265_4000
+#EXTINF:-1,tvg-id="天津卫视" tvg-name="天津卫视" tvg-logo="https://epg.112114.xyz/logo/天津卫视.png" group-title="卫视",天津卫视
+http://192.168.10.1:5678/sxg.php?id=tjwsH265_4000
+#EXTINF:-1,tvg-id="西藏卫视" tvg-name="西藏卫视" tvg-logo="https://epg.112114.xyz/logo/西藏卫视.png" group-title="卫视",西藏卫视
+http://192.168.10.1:5678/sxg.php?id=xzwsH264_2000
+#EXTINF:-1,tvg-id="云南卫视" tvg-name="云南卫视" tvg-logo="https://epg.112114.xyz/logo/云南卫视.png" group-title="卫视",云南卫视
+http://192.168.10.1:5678/sxg.php?id=ynws_4000
+#EXTINF:-1,tvg-id="浙江卫视" tvg-name="浙江卫视" tvg-logo="https://epg.112114.xyz/logo/浙江卫视.png" group-title="卫视",浙江卫视
+http://192.168.10.1:5678/sxg.php?id=zjwsH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CETV1.png" group-title="其他",CETV-1
+http://192.168.10.1:5678/sxg.php?id=CETV-1H264_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CETV4.png" group-title="其他",CETV-4
 http://192.168.10.1:5678/sxg.php?id=CETV-4H264_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN英语.png" group-title="央视",CGTN-英语 标清
-http://192.168.10.1:5678/sxg.php?id=CGTN_4000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN西语.png" group-title="央视",CGTN-西语 标清
-http://192.168.10.1:5678/sxg.php?id=xbyy_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN法语.png" group-title="央视",CGTN-法语 标清
-http://192.168.10.1:5678/sxg.php?id=fy_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN俄语.png" group-title="央视",CGTN-俄语 标清
+#EXTINF:-1,tvg-id="风尚生活" tvg-name="风尚生活" tvg-logo="https://epg.112114.xyz/logo/风尚生活.png" group-title="其他",CBN风尚生活
+http://192.168.10.1:5678/sxg.php?id=fssh_4000
+#EXTINF:-1,tvg-id="每日影院" tvg-name="每日影院" tvg-logo="https://epg.112114.xyz/logo/每日影院.png" group-title="其他",CBN每日影院
+http://192.168.10.1:5678/sxg.php?id=mryy_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CBN幸福剧场.png" group-title="其他",CBN幸福剧场
+http://192.168.10.1:5678/sxg.php?id=xfjc_4000
+#EXTINF:-1,tvg-id="幸福娱乐" tvg-name="幸福娱乐" tvg-logo="https://epg.112114.xyz/logo/幸福娱乐.png" group-title="其他",CBN幸福娱乐
+http://192.168.10.1:5678/sxg.php?id=xfyl_4000
+#EXTINF:-1,tvg-id="CHC动作电影" tvg-name="CHC动作电影" tvg-logo="https://epg.112114.xyz/logo/CHC动作电影.png" group-title="其他",CHC动作电影
+http://192.168.10.1:5678/sxg.php?id=wqCHCdzdyH265_4000
+#EXTINF:-1,tvg-id="CHC高清电影" tvg-name="CHC高清电影" tvg-logo="https://epg.112114.xyz/logo/CHC高清电影.png" group-title="其他",CHC高清电影
+http://192.168.10.1:5678/sxg.php?id=lnwsCHC-HDH265_4000
+#EXTINF:-1,tvg-id="CHC家庭影院" tvg-name="CHC家庭影院" tvg-logo="https://epg.112114.xyz/logo/CHC家庭影院.png" group-title="其他",CHC家庭影院
+http://192.168.10.1:5678/sxg.php?id=jbtygqCHCjtyyH265_4000
+#EXTINF:-1,tvg-id="动漫秀场" tvg-name="动漫秀场" tvg-logo="https://epg.112114.xyz/logo/动漫秀场.png" group-title="其他",动漫秀场
+http://192.168.10.1:5678/sxg.php?id=yybb-dmxc-H265_4000
+#EXTINF:-1,tvg-id="SITV都市剧场" tvg-name="SITV都市剧场" tvg-logo="https://epg.112114.xyz/logo/SITV都市剧场.png" group-title="其他",都市剧场
+http://192.168.10.1:5678/sxg.php?id=yxfydsjcHDH265_4000
+#EXTINF:-1,tvg-id="SITV法治天地" tvg-name="SITV法治天地" tvg-logo="https://epg.112114.xyz/logo/SITV法治天地.png" group-title="其他",法治天地
+http://192.168.10.1:5678/sxg.php?id=fztx_4000
+#EXTINF:-1,tvg-id="MAX极速汽车" tvg-name="MAX极速汽车" tvg-logo="https://epg.112114.xyz/logo/MAX极速汽车.png" group-title="其他",极速汽车
+http://192.168.10.1:5678/sxg.php?id=jsqcH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/纪实科教.png" group-title="其他",纪实科教
+http://192.168.10.1:5678/sxg.php?id=bjjs_2000
+#EXTINF:-1,tvg-id="嘉佳卡通" tvg-name="嘉佳卡通" tvg-logo="https://epg.112114.xyz/logo/嘉佳卡通.png" group-title="其他",嘉佳卡通
+http://192.168.10.1:5678/sxg.php?id=jjkt_2000
+#EXTINF:-1,tvg-id="家庭理财" tvg-name="家庭理财" tvg-logo="https://epg.112114.xyz/logo/家庭理财.png" group-title="其他",家庭理财
+http://192.168.10.1:5678/sxg.php?id=jtlc_4000
+#EXTINF:-1,tvg-id="财富天下" tvg-name="财富天下" tvg-logo="https://epg.112114.xyz/logo/财富天下.png" group-title="江苏",江苏财富天下
+http://192.168.10.1:5678/sxg.php?id=cftx_4000
+#EXTINF:-1,tvg-id="金鹰纪实" tvg-name="金鹰纪实" tvg-logo="https://epg.112114.xyz/logo/金鹰纪实.png" group-title="其他",金鹰纪实
+http://192.168.10.1:5678/sxg.php?id=jyjsHDH265_4000
+#EXTINF:-1,tvg-id="湖南金鹰卡通" tvg-name="湖南金鹰卡通" tvg-logo="https://epg.112114.xyz/logo/湖南金鹰卡通.png" group-title="其他",金鹰卡通
+http://192.168.10.1:5678/sxg.php?id=jykt_2000
+#EXTINF:-1,tvg-id="SITV劲爆体育" tvg-name="SITV劲爆体育" tvg-logo="https://epg.112114.xyz/logo/SITV劲爆体育.png" group-title="其他",劲爆体育
+http://192.168.10.1:5678/sxg.php?id=lqhxjcHDH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/聚鲨环球精选.png" group-title="其他",聚鲨环球精选
+http://192.168.10.1:5678/sxg.php?id=jshqjxHD_4000
+#EXTINF:-1,tvg-id="卡酷少儿" tvg-name="卡酷少儿" tvg-logo="https://epg.112114.xyz/logo/卡酷少儿.png" group-title="其他",卡酷少儿
+http://192.168.10.1:5678/sxg.php?id=kkkt_4000
+#EXTINF:-1,tvg-id="快乐垂钓" tvg-name="快乐垂钓" tvg-logo="https://epg.112114.xyz/logo/快乐垂钓.png" group-title="其他",快乐垂钓
+http://192.168.10.1:5678/sxg.php?id=fyzqklcdHDH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐游.png" group-title="其他",乐游
+http://192.168.10.1:5678/sxg.php?id=qjs-HDH265_4000
+#EXTINF:-1,tvg-id="梨园" tvg-name="梨园" tvg-logo="https://epg.112114.xyz/logo/梨园.png" group-title="其他",梨园频道
+http://192.168.10.1:5678/sxg.php?id=ly_4000
+#EXTINF:-1,tvg-id="魅力足球" tvg-name="魅力足球" tvg-logo="https://epg.112114.xyz/logo/魅力足球.png" group-title="其他",魅力足球
+http://192.168.10.1:5678/sxg.php?id=mlyy_4000
+#EXTINF:-1,tvg-id="SITV七彩戏剧" tvg-name="SITV七彩戏剧" tvg-logo="https://epg.112114.xyz/logo/SITV七彩戏剧.png" group-title="其他",七彩戏剧
+http://192.168.10.1:5678/sxg.php?id=qcxj_2000
+#EXTINF:-1,tvg-id="摄影" tvg-name="摄影" tvg-logo="https://epg.112114.xyz/logo/摄影.png" group-title="其他",摄影频道
+http://192.168.10.1:5678/sxg.php?id=sy_4000
+#EXTINF:-1,tvg-id="生活时尚" tvg-name="生活时尚" tvg-logo="https://epg.112114.xyz/logo/生活时尚.png" group-title="其他",生活时尚
+http://192.168.10.1:5678/sxg.php?id=shssH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四海钓鱼.png" group-title="其他",四海钓鱼
+http://192.168.10.1:5678/sxg.php?id=shdy_4000
+#EXTINF:-1,tvg-id="天元围棋" tvg-name="天元围棋" tvg-logo="https://epg.112114.xyz/logo/天元围棋.png" group-title="其他",天元围棋
+http://192.168.10.1:5678/sxg.php?id=tywq_2000
+#EXTINF:-1,tvg-id="武术世界" tvg-name="武术世界" tvg-logo="https://epg.112114.xyz/logo/武术世界.png" group-title="其他",武术世界
+http://192.168.10.1:5678/sxg.php?id=wssj_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/先锋乒羽.png" group-title="其他",先锋乒羽
+http://192.168.10.1:5678/sxg.php?id=xfpy_4000
+#EXTINF:-1,tvg-id="新视觉" tvg-name="新视觉" tvg-logo="https://epg.112114.xyz/logo/新视觉.png" group-title="其他",新视觉
+http://192.168.10.1:5678/sxg.php?id=ycxsjH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/证劵服务.png" group-title="其他",证劵服务
+http://192.168.10.1:5678/sxg.php?id=jz_2000
+#EXTINF:-1,tvg-id="中国天气" tvg-name="中国天气" tvg-logo="https://epg.112114.xyz/logo/中国天气.png" group-title="其他",中国天气
+http://192.168.10.1:5678/sxg.php?id=zgqx_4000
+#EXTINF:-1,tvg-id="发现之旅" tvg-name="发现之旅" tvg-logo="https://epg.112114.xyz/logo/发现之旅.png" group-title="央视",中央新影-发现之旅
+http://192.168.10.1:5678/sxg.php?id=fxzl_2000
+#EXTINF:-1,tvg-id="老故事" tvg-name="老故事" tvg-logo="https://epg.112114.xyz/logo/老故事.png" group-title="央视",中央新影-老故事
+http://192.168.10.1:5678/sxg.php?id=lgs_2000
+#EXTINF:-1,tvg-id="中学生" tvg-name="中学生" tvg-logo="https://epg.112114.xyz/logo/中学生.png" group-title="央视",中央新影-中学生
+http://192.168.10.1:5678/sxg.php?id=zxs_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/川广融媒.png" group-title="其他",川广融媒
+http://192.168.10.1:5678/sxg.php?id=cgrh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/川网导视.png" group-title="其他",川网导视
+http://192.168.10.1:5678/sxg.php?id=cwdsHDH264_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/精品导视.png" group-title="其他",精品导视
+http://192.168.10.1:5678/sxg.php?id=jpdsH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/沙湾融媒.png" group-title="其他",沙湾融媒
+http://192.168.10.1:5678/sxg.php?id=swxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川文化旅游.png" group-title="四川",四川文化旅游
+http://192.168.10.1:5678/sxg.php?id=SCTV-2-H265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川经济.png" group-title="四川",四川经济
+http://192.168.10.1:5678/sxg.php?id=SCTV-3-H265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川新闻.png" group-title="四川",四川新闻
+http://192.168.10.1:5678/sxg.php?id=SCTV-4H265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川影视文艺.png" group-title="四川",四川影视文艺
+http://192.168.10.1:5678/sxg.php?id=SCTV-5-scysH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川妇女儿童.png" group-title="四川",四川妇女儿童
+http://192.168.10.1:5678/sxg.php?id=SCTV-7-_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川科教.png" group-title="四川",四川科教
+http://192.168.10.1:5678/sxg.php?id=SCTV-ggSCTV-8_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/四川乡村.png" group-title="四川",四川乡村
+http://192.168.10.1:5678/sxg.php?id=SCTV-kjSCTV-9-_4000
+#EXTINF:-1,tvg-id="峨嵋电影" tvg-name="峨嵋电影" tvg-logo="https://epg.112114.xyz/logo/峨嵋电影.png" group-title="四川",四川峨嵋电影
+http://192.168.10.1:5678/sxg.php?id=emdygqH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都新闻综合.png" group-title="其他",成都新闻综合
+http://192.168.10.1:5678/sxg.php?id=CDTV-1_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都经济资讯.png" group-title="其他",成都经济资讯
+http://192.168.10.1:5678/sxg.php?id=CDTV-2_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都都市生活.png" group-title="其他",成都都市生活
+http://192.168.10.1:5678/sxg.php?id=CDTV-3_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都影视文艺.png" group-title="其他",成都影视文艺
+http://192.168.10.1:5678/sxg.php?id=CDTV-4_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都公共.png" group-title="其他",成都公共频道
+http://192.168.10.1:5678/sxg.php?id=CDTV-5_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都高新区.png" group-title="其他",成都高新区
+http://192.168.10.1:5678/sxg.php?id=cdgxdstgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/成都每日购物.png" group-title="其他",成都每日购物
+http://192.168.10.1:5678/sxg.php?id=mrgw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/阿坝州TV.png" group-title="其他",阿坝州TV
+http://192.168.10.1:5678/sxg.php?id=abxwzhpdgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/阿坝州藏语.png" group-title="其他",阿坝州藏语
+http://192.168.10.1:5678/sxg.php?id=wypdgqH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/安居综合.png" group-title="其他",安居综合
+http://192.168.10.1:5678/sxg.php?id=ajxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/安岳综合.png" group-title="其他",安岳综合频道
+http://192.168.10.1:5678/sxg.php?id=ayxwzh_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/安州综合.png" group-title="其他",安州综合频道
+http://192.168.10.1:5678/sxg.php?id=azgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/巴中文旅生活.png" group-title="其他",巴中文旅生活
+http://192.168.10.1:5678/sxg.php?id=bzetH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/巴中综合.png" group-title="其他",巴中综合
+http://192.168.10.1:5678/sxg.php?id=bzytH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/巴州电视.png" group-title="其他",巴州电视
+http://192.168.10.1:5678/sxg.php?id=bzxw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宝兴综合.png" group-title="其他",宝兴综合
+http://192.168.10.1:5678/sxg.php?id=bxdst_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/北川综合.png" group-title="其他",北川综合
+http://192.168.10.1:5678/sxg.php?id=bcxwHD_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/苍溪综合.png" group-title="其他",苍溪综合
+http://192.168.10.1:5678/sxg.php?id=cxxwgqH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/长宁综合.png" group-title="其他",长宁综合
+http://192.168.10.1:5678/sxg.php?id=znzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/朝天综合.png" group-title="其他",朝天综合
+http://192.168.10.1:5678/sxg.php?id=ctxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/崇州.png" group-title="其他",崇州
+http://192.168.10.1:5678/sxg.php?id=czyt_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/船山综合.png" group-title="其他",船山综合
+http://192.168.10.1:5678/sxg.php?id=csxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达川新闻综合.png" group-title="其他",达川新闻综合
+http://192.168.10.1:5678/sxg.php?id=dcxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州导视.png" group-title="其他",达州导视
+http://192.168.10.1:5678/sxg.php?id=dzds_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州公共.png" group-title="其他",达州公共
+http://192.168.10.1:5678/sxg.php?id=dzgg_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州通川.png" group-title="其他",达州通川
+http://192.168.10.1:5678/sxg.php?id=tcq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/达州新闻综合.png" group-title="其他",达州新闻综合
+http://192.168.10.1:5678/sxg.php?id=dzxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/大邑电视台.png" group-title="其他",大邑电视台
+http://192.168.10.1:5678/sxg.php?id=dyytH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/大英新闻综合.png" group-title="其他",大英新闻综合
+http://192.168.10.1:5678/sxg.php?id=dyxwzhH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/丹棱综合.png" group-title="其他",丹棱综合
+http://192.168.10.1:5678/sxg.php?id=dlxwzhH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/德昌电视台.png" group-title="其他",德昌电视台
+http://192.168.10.1:5678/sxg.php?id=dcxw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/东兴综合.png" group-title="其他",东兴综合
+http://192.168.10.1:5678/sxg.php?id=dxxwzh_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/都江堰.png" group-title="其他",都江堰
+http://192.168.10.1:5678/sxg.php?id=djyzh_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/峨边电视台.png" group-title="其他",峨边电视台
+http://192.168.10.1:5678/sxg.php?id=ebdst_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/峨眉综合.png" group-title="其他",峨眉综合
+http://192.168.10.1:5678/sxg.php?id=emsxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/恩阳新闻.png" group-title="其他",恩阳新闻
+http://192.168.10.1:5678/sxg.php?id=eyxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/涪城综合.png" group-title="其他",涪城综合
+http://192.168.10.1:5678/sxg.php?id=fcgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/富顺综合.png" group-title="其他",富顺综合
+http://192.168.10.1:5678/sxg.php?id=fszh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/甘洛.png" group-title="其他",甘洛
+http://192.168.10.1:5678/sxg.php?id=glt_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/甘孜综合.png" group-title="其他",甘孜综合
+http://192.168.10.1:5678/sxg.php?id=gzxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/高县1.png" group-title="其他",高县-1
+http://192.168.10.1:5678/sxg.php?id=gxt_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/古蔺新闻综合.png" group-title="其他",古蔺新闻综合
+http://192.168.10.1:5678/sxg.php?id=glxwzhgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广安公共.png" group-title="其他",广安公共
+http://192.168.10.1:5678/sxg.php?id=gagg_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广安区电视台.png" group-title="其他",广安区电视台
+http://192.168.10.1:5678/sxg.php?id=gaqxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广安新闻综合.png" group-title="其他",广安新闻综合
+http://192.168.10.1:5678/sxg.php?id=gaxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广汉综合.png" group-title="其他",广汉综合
+http://192.168.10.1:5678/sxg.php?id=ghxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广元文化生活.png" group-title="其他",广元文化生活
+http://192.168.10.1:5678/sxg.php?id=gyggH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/广元综合.png" group-title="其他",广元综合
+http://192.168.10.1:5678/sxg.php?id=gyzhH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/汉源综合.png" group-title="其他",汉源综合
+http://192.168.10.1:5678/sxg.php?id=hyxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/合江新闻综合.png" group-title="其他",合江新闻综合
+http://192.168.10.1:5678/sxg.php?id=hjxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/黑水.png" group-title="其他",黑水
+http://192.168.10.1:5678/sxg.php?id=hsxwzhpdH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/洪雅新闻综合.png" group-title="其他",洪雅新闻综合
+http://192.168.10.1:5678/sxg.php?id=hyzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/华蓥综合.png" group-title="其他",华蓥综合
+http://192.168.10.1:5678/sxg.php?id=hyxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/会理新闻.png" group-title="其他",会理新闻
+http://192.168.10.1:5678/sxg.php?id=hlyt_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/夹江新闻综合.png" group-title="其他",夹江新闻综合
+http://192.168.10.1:5678/sxg.php?id=jjxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/简阳新闻综合.png" group-title="其他",简阳新闻综合
+http://192.168.10.1:5678/sxg.php?id=jyxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/剑阁综合.png" group-title="其他",剑阁综合
+http://192.168.10.1:5678/sxg.php?id=jgxwzhH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/江安电视台.png" group-title="其他",江安电视台
+http://192.168.10.1:5678/sxg.php?id=jat_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/江油综合.png" group-title="其他",江油综合
+http://192.168.10.1:5678/sxg.php?id=jyxwHD_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/金口河综合.png" group-title="其他",金口河综合
+http://192.168.10.1:5678/sxg.php?id=jkhdst_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/金牛.png" group-title="其他",金牛
+http://192.168.10.1:5678/sxg.php?id=jnyx_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/金堂电视台.png" group-title="其他",金堂电视台
+http://192.168.10.1:5678/sxg.php?id=jtzhpd_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/开江新闻综合.png" group-title="其他",开江新闻综合
+http://192.168.10.1:5678/sxg.php?id=kjxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐山公共.png" group-title="其他",乐山公共
+http://192.168.10.1:5678/sxg.php?id=lsggpd_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/乐山新闻综合.png" group-title="其他",乐山新闻综合
+http://192.168.10.1:5678/sxg.php?id=lsxwzh_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/利州综合.png" group-title="其他",利州综合
+http://192.168.10.1:5678/sxg.php?id=lzxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/凉山新闻综合.png" group-title="其他",凉山新闻综合
+http://192.168.10.1:5678/sxg.php?id=lsxwHDH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/凉山彝语综合.png" group-title="其他",凉山彝语综合
+http://192.168.10.1:5678/sxg.php?id=yyzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/邻水.png" group-title="其他",邻水
+http://192.168.10.1:5678/sxg.php?id=lsxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/龙泉综合.png" group-title="其他",龙泉综合
+http://192.168.10.1:5678/sxg.php?id=lqxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/隆昌综合.png" group-title="其他",隆昌综合
+http://192.168.10.1:5678/sxg.php?id=lcxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/芦山综合.png" group-title="其他",芦山综合频道
+http://192.168.10.1:5678/sxg.php?id=lszh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/罗江.png" group-title="其他",罗江
+http://192.168.10.1:5678/sxg.php?id=ljxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/马边综合.png" group-title="其他",马边综合
+http://192.168.10.1:5678/sxg.php?id=mbxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/马尔康.png" group-title="其他",马尔康
+http://192.168.10.1:5678/sxg.php?id=mekxwzhpd_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/眉山综合.png" group-title="其他",眉山综合
+http://192.168.10.1:5678/sxg.php?id=msxwzhgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/米易综合.png" group-title="其他",米易综合
+http://192.168.10.1:5678/sxg.php?id=myxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/绵阳科技.png" group-title="其他",绵阳科技
+http://192.168.10.1:5678/sxg.php?id=myetH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/绵阳新闻综合.png" group-title="其他",绵阳新闻综合
+http://192.168.10.1:5678/sxg.php?id=myytH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/绵竹.png" group-title="其他",绵竹
+http://192.168.10.1:5678/sxg.php?id=mzxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/冕宁综合.png" group-title="其他",冕宁综合
+http://192.168.10.1:5678/sxg.php?id=mnxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/名山电视台.png" group-title="其他",名山电视台
+http://192.168.10.1:5678/sxg.php?id=msdstH265_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/木里.png" group-title="其他",木里
+http://192.168.10.1:5678/sxg.php?id=mltHD_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/纳溪1.png" group-title="其他",纳溪-1
+http://192.168.10.1:5678/sxg.php?id=nxxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南部综合.png" group-title="其他",南部综合
+http://192.168.10.1:5678/sxg.php?id=nbxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南充综合.png" group-title="其他",南充综合
+http://192.168.10.1:5678/sxg.php?id=ncxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南江电视台.png" group-title="其他",南江电视台
+http://192.168.10.1:5678/sxg.php?id=njxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/南溪综合.png" group-title="其他",南溪综合
+http://192.168.10.1:5678/sxg.php?id=nxt_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/内江公共.png" group-title="其他",内江公共
+http://192.168.10.1:5678/sxg.php?id=njgg_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/内江综合.png" group-title="其他",内江综合
+http://192.168.10.1:5678/sxg.php?id=njzh_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宁南综合.png" group-title="其他",宁南综合
+http://192.168.10.1:5678/sxg.php?id=nnt_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/攀钢新闻综合.png" group-title="其他",攀钢新闻综合
+http://192.168.10.1:5678/sxg.php?id=pgxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/攀枝花新闻综合.png" group-title="其他",攀枝花新闻综合
+http://192.168.10.1:5678/sxg.php?id=pzhytH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/彭山综合.png" group-title="其他",彭山综合
+http://192.168.10.1:5678/sxg.php?id=pszh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/彭州综合.png" group-title="其他",彭州综合
+http://192.168.10.1:5678/sxg.php?id=pzxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/蓬安综合.png" group-title="其他",蓬安综合
+http://192.168.10.1:5678/sxg.php?id=pazh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/蓬溪新闻综合.png" group-title="其他",蓬溪新闻综合
+http://192.168.10.1:5678/sxg.php?id=pxxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/平昌综合.png" group-title="其他",平昌综合
+http://192.168.10.1:5678/sxg.php?id=pcxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/平武综合.png" group-title="其他",平武综合
+http://192.168.10.1:5678/sxg.php?id=pwgq_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/屏山综合.png" group-title="其他",屏山综合
+http://192.168.10.1:5678/sxg.php?id=psxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/蒲江综合.png" group-title="其他",蒲江综合
+http://192.168.10.1:5678/sxg.php?id=pjxw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/普格综合.png" group-title="其他",普格综合
+http://192.168.10.1:5678/sxg.php?id=pgt_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/前锋.png" group-title="其他",前锋
+http://192.168.10.1:5678/sxg.php?id=qfxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/青白江综合.png" group-title="其他",青白江综合
+http://192.168.10.1:5678/sxg.php?id=qbjxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/青川综合.png" group-title="其他",青川综合
+http://192.168.10.1:5678/sxg.php?id=qcxwzhH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/青神综合.png" group-title="其他",青神综合
+http://192.168.10.1:5678/sxg.php?id=qszh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/渠县新闻综合.png" group-title="其他",渠县新闻综合
+http://192.168.10.1:5678/sxg.php?id=qxxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/仁和新闻.png" group-title="其他",仁和新闻
+http://192.168.10.1:5678/sxg.php?id=rhxwH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/荣县综合.png" group-title="其他",荣县综合
+http://192.168.10.1:5678/sxg.php?id=rxzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/三台TV.png" group-title="其他",三台TV
+http://192.168.10.1:5678/sxg.php?id=stxwHD_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/射洪综合.png" group-title="其他",射洪综合
+http://192.168.10.1:5678/sxg.php?id=shzhH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/石棉.png" group-title="其他",石棉
+http://192.168.10.1:5678/sxg.php?id=smxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/什邡新闻综合.png" group-title="其他",什邡新闻综合
+http://192.168.10.1:5678/sxg.php?id=sfx_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/双流综合.png" group-title="其他",双流综合
+http://192.168.10.1:5678/sxg.php?id=slgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/松潘.png" group-title="其他",松潘
+http://192.168.10.1:5678/sxg.php?id=spxwzhpdH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/遂宁综合.png" group-title="其他",遂宁综合
+http://192.168.10.1:5678/sxg.php?id=snxwzhHDH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/天全新闻.png" group-title="其他",天全新闻
+http://192.168.10.1:5678/sxg.php?id=tqzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/通川区.png" group-title="其他",通川区
+http://192.168.10.1:5678/sxg.php?id=xcxwzhH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/通江综合.png" group-title="其他",通江综合
+http://192.168.10.1:5678/sxg.php?id=tjxwH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/万源.png" group-title="其他",万源
+http://192.168.10.1:5678/sxg.php?id=wyxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/旺苍新闻综合.png" group-title="其他",旺苍新闻综合
+http://192.168.10.1:5678/sxg.php?id=wcxwzhH265_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/温江综合.png" group-title="其他",温江综合频道
+http://192.168.10.1:5678/sxg.php?id=wjytH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/武胜综合.png" group-title="其他",武胜综合
+http://192.168.10.1:5678/sxg.php?id=wsxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/五通桥.png" group-title="其他",五通桥
+http://192.168.10.1:5678/sxg.php?id=wtqxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/西昌.png" group-title="其他",西昌
+http://192.168.10.1:5678/sxg.php?id=xctHD_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/西充综合.png" group-title="其他",西充综合
+http://192.168.10.1:5678/sxg.php?id=xczh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/喜德.png" group-title="其他",喜德
+http://192.168.10.1:5678/sxg.php?id=xdxw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/新都综合.png" group-title="其他",新都综合
+http://192.168.10.1:5678/sxg.php?id=xdzhpd_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/新津.png" group-title="其他",新津
+http://192.168.10.1:5678/sxg.php?id=xjzh_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/兴文电视台.png" group-title="其他",兴文电视台
+http://192.168.10.1:5678/sxg.php?id=xwt_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/叙永电视台.png" group-title="其他",叙永电视台
+http://192.168.10.1:5678/sxg.php?id=xyxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/叙州新闻综合.png" group-title="其他",叙州新闻综合
+http://192.168.10.1:5678/sxg.php?id=ybx_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宣汉综合.png" group-title="其他",宣汉综合
+http://192.168.10.1:5678/sxg.php?id=xhxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雅安公共.png" group-title="其他",雅安公共
+http://192.168.10.1:5678/sxg.php?id=yagg_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雅安新闻综合.png" group-title="其他",雅安新闻综合
+http://192.168.10.1:5678/sxg.php?id=yazh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雅安雨城.png" group-title="其他",雅安雨城
+http://192.168.10.1:5678/sxg.php?id=ycpd_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/盐边电视台.png" group-title="其他",盐边电视台
+http://192.168.10.1:5678/sxg.php?id=ybtgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/盐亭1.png" group-title="其他",盐亭1
+http://192.168.10.1:5678/sxg.php?id=ytzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/雁江.png" group-title="其他",雁江
+http://192.168.10.1:5678/sxg.php?id=yjxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/仪陇新闻综合.png" group-title="其他",仪陇新闻综合
+http://192.168.10.1:5678/sxg.php?id=ylxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宜宾公共.png" group-title="其他",宜宾公共
+http://192.168.10.1:5678/sxg.php?id=ybetH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/宜宾新闻综合.png" group-title="其他",宜宾新闻综合
+http://192.168.10.1:5678/sxg.php?id=ybytH264_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/营山.png" group-title="其他",营山
+http://192.168.10.1:5678/sxg.php?id=ysxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/越西综合.png" group-title="其他",越西综合
+http://192.168.10.1:5678/sxg.php?id=yxt_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/岳池.png" group-title="其他",岳池
+http://192.168.10.1:5678/sxg.php?id=ycxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/昭化综合.png" group-title="其他",昭化综合
+http://192.168.10.1:5678/sxg.php?id=zhxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/中江新闻综合.png" group-title="其他",中江新闻综合
+http://192.168.10.1:5678/sxg.php?id=zjxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/资阳新闻综合.png" group-title="其他",资阳新闻综合
+http://192.168.10.1:5678/sxg.php?id=zyxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/资中综合.png" group-title="其他",资中综合
+http://192.168.10.1:5678/sxg.php?id=zzzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/自贡文化生活.png" group-title="其他",自贡文化生活
+http://192.168.10.1:5678/sxg.php?id=zggg_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/自贡综合.png" group-title="其他",自贡综合
+http://192.168.10.1:5678/sxg.php?id=zgxw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/郫县新闻综合.png" group-title="其他",郫县新闻综合
+http://192.168.10.1:5678/sxg.php?id=pxds1_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/荥经电视台.png" group-title="其他",荥经电视台
+http://192.168.10.1:5678/sxg.php?id=xjdst_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/阆中综合.png" group-title="其他",阆中综合
+http://192.168.10.1:5678/sxg.php?id=lzxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/沐川综合.png" group-title="其他",沐川综合
+http://192.168.10.1:5678/sxg.php?id=mcxw_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/泸定综合.png" group-title="其他",泸定综合频道
+http://192.168.10.1:5678/sxg.php?id=ldxw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/泸县综合.png" group-title="其他",泸县综合
+http://192.168.10.1:5678/sxg.php?id=lxxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/泸州公共.png" group-title="其他",泸州公共
+http://192.168.10.1:5678/sxg.php?id=lzgg_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/珙县新闻.png" group-title="其他",珙县新闻
+http://192.168.10.1:5678/sxg.php?id=gxzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/梓潼综合.png" group-title="其他",梓潼综合
+http://192.168.10.1:5678/sxg.php?id=ztgq_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/犍为新闻综合.png" group-title="其他",犍为新闻综合
+http://192.168.10.1:5678/sxg.php?id=qwxwzh_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/筠连TV.png" group-title="其他",筠连TV
+http://192.168.10.1:5678/sxg.php?id=ylyt_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN俄语.png" group-title="央视",CGTN-俄语
 http://192.168.10.1:5678/sxg.php?id=ey_2000
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/优购物.png" group-title="其他",优购物 标清
-http://192.168.10.1:5678/sxg.php?id=ygw
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/风尚购物.png" group-title="其他",风尚购物 标清
-http://192.168.10.1:5678/sxg.php?id=fsgw
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/家有购物.png" group-title="其他",家有购物 标清
-http://192.168.10.1:5678/sxg.php?id=jygw
-#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/家家购物.png" group-title="其他",家家购物 标清
-http://192.168.10.1:5678/sxg.php?id=jjgw
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN法语.png" group-title="央视",CGTN-法语
+http://192.168.10.1:5678/sxg.php?id=fy_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN西语.png" group-title="央视",CGTN-西语
+http://192.168.10.1:5678/sxg.php?id=xbyy_2000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/CGTN英语.png" group-title="央视",CGTN-英语
+http://192.168.10.1:5678/sxg.php?id=CGTN_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/风尚购物.png" group-title="其他",风尚购物
+http://192.168.10.1:5678/sxg.php?id=fsgw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/家家购物.png" group-title="其他",家家购物
+http://192.168.10.1:5678/sxg.php?id=jjgw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/家有购物.png" group-title="其他",家有购物
+http://192.168.10.1:5678/sxg.php?id=jygw_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/央广购物.png" group-title="其他",央广购物
+http://192.168.10.1:5678/sxg.php?id=yggwgq_4000
+#EXTINF:-1,tvg-id="" tvg-name="" tvg-logo="https://epg.112114.xyz/logo/优购物.png" group-title="其他",优购物
+http://192.168.10.1:5678/sxg.php?id=ygw_4000


### PR DESCRIPTION
# 更新内容

**谷豆：**

- 添加部分广东地方频道（共128频道）。

**蜀小果：**

- 添加部分四川地方频道（共277频道）。
- 去除高清/标清字样，理由是测试很多带标清字样的频道使用高清方式播出，为了避免混淆统一去除。
- 去除重复以及名称错误的频道。
- 优化排序，将央视卫视 放在地方台之前。
- 一些原本就无法播放的频道未处理，维持原样。
