### PR TITLE
refactor: 减小docker镜像体积

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.19-alpine AS build
 
 WORKDIR /app
 
@@ -10,6 +10,10 @@ COPY ./Golang/*.go ./
 COPY ./Golang/liveurls/*.go ./liveurls/
 
 RUN go build -o /allinone
+
+FROM alpine:3.14
+
+COPY --from=build /allinone /allinone
 
 EXPOSE 35455
 


### PR DESCRIPTION
从原先的580+M减小到29M